### PR TITLE
Cleanup golangci-lint configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,50 +1,29 @@
 linters:
   enable-all: true
   disable:
-    - exhaustruct
-    - wrapcheck
-    - nolintlint
-    - wastedassign
-    - varnamelen
-    - forcetypeassert
-    - err113
-    - ireturn
-    - funlen
-    - forbidigo
-    - godot
-    - godox
     - cyclop
-    - prealloc
-    - dupl
-    - lll
-    - goconst
     - depguard
+    - err113
     - exhaustive
-    - wsl
-    - unparam
-    - gomoddirectives
-    - gofumpt
-    - nestif
-    - paralleltest
-    - testpackage
+    - exhaustruct
+    - funlen
     - gocognit
-    - tagliatelle
-    - nlreturn
-    - gocyclo
-    # added from 1.60.3
-    - revive
-    - govet
-    - intrange
+    - godox
+    - lll
     - mnd
-    - perfsprint
-    - musttag
+    - nlreturn
+    - paralleltest
+    - tagalign
+    - tagliatelle
+    - wrapcheck
+    - wsl
 
 linters-settings:
   errcheck:
-    exclude-functions: 
-     - fmt:.*
+    exclude-functions:
+      - fmt:.*
 
 run:
   modules-download-mode: vendor
   timeout: 3m
-  go: '1.23'
+  go: '1.24'

--- a/cmd/config/command.go
+++ b/cmd/config/command.go
@@ -10,7 +10,8 @@ func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Apply a YAML dashboard",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
+			//nolint:forbidigo
 			fmt.Println("config subcommand")
 		},
 	}

--- a/devbox.json
+++ b/devbox.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/main/.schema/devbox.schema.json",
   "packages": [
     "go@1.24",
-    "golangci-lint@1.62",
+    "golangci-lint@1.64",
     "goreleaser@2.4"
   ],
   "shell": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -2,7 +2,7 @@
   "lockfile_version": "1",
   "packages": {
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/02032da4af073d0f6110540c8677f16d4be0117f?lastModified=1741037377&narHash=sha256-SvtvVKHaUX4Owb%2BPasySwZsoc5VUeTf1px34BByiOxw%3D"
+      "resolved": "github:NixOS/nixpkgs/2d9e4457f8e83120c9fdf6f1707ed0bc603e5ac9?lastModified=1741462378&narHash=sha256-ZF3YOjq%2BvTcH51S%2BqWa1oGA9FgmdJ67nTNPG2OIlXDc%3D"
     },
     "go@1.24": {
       "last_modified": "2025-02-12T00:10:52Z",
@@ -52,51 +52,51 @@
         }
       }
     },
-    "golangci-lint@1.62": {
-      "last_modified": "2024-12-23T21:10:33Z",
-      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#golangci-lint",
+    "golangci-lint@1.64": {
+      "last_modified": "2025-02-16T21:44:05Z",
+      "resolved": "github:NixOS/nixpkgs/f0204ef4baa3b6317dee1c84ddeffbd293638836#golangci-lint",
       "source": "devbox-search",
-      "version": "1.62.2",
+      "version": "1.64.5",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/5liapbkl2xs5kww2wvs2yv8grhcaswwl-golangci-lint-1.62.2",
+              "path": "/nix/store/jh2f466rbi0pgk6f3w8jdzy4qyccybz3-golangci-lint-1.64.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/5liapbkl2xs5kww2wvs2yv8grhcaswwl-golangci-lint-1.62.2"
+          "store_path": "/nix/store/jh2f466rbi0pgk6f3w8jdzy4qyccybz3-golangci-lint-1.64.5"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/87ihwdp39vxi97q0bfv8isw2p1pyz257-golangci-lint-1.62.2",
+              "path": "/nix/store/63mvzwlqana7bfcy8jzmn3fvkn46k0p6-golangci-lint-1.64.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/87ihwdp39vxi97q0bfv8isw2p1pyz257-golangci-lint-1.62.2"
+          "store_path": "/nix/store/63mvzwlqana7bfcy8jzmn3fvkn46k0p6-golangci-lint-1.64.5"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/73jfn21by312v2jawvmb9rkjhls28ry7-golangci-lint-1.62.2",
+              "path": "/nix/store/d662i9k8p2alplmxc3bqypc646x7wy1b-golangci-lint-1.64.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/73jfn21by312v2jawvmb9rkjhls28ry7-golangci-lint-1.62.2"
+          "store_path": "/nix/store/d662i9k8p2alplmxc3bqypc646x7wy1b-golangci-lint-1.64.5"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/rzvlg3gzv8cgr4qpvsxx1q8pmgdl9j95-golangci-lint-1.62.2",
+              "path": "/nix/store/25732rsdh49iwjrik69sb9cfhiza00b5-golangci-lint-1.64.5",
               "default": true
             }
           ],
-          "store_path": "/nix/store/rzvlg3gzv8cgr4qpvsxx1q8pmgdl9j95-golangci-lint-1.62.2"
+          "store_path": "/nix/store/25732rsdh49iwjrik69sb9cfhiza00b5-golangci-lint-1.64.5"
         }
       }
     },


### PR DESCRIPTION
Cleanup the configuration used by golangci-lint and use a more up-to-date version of it.