### PR TITLE
Make the generated cli reference deterministic

### DIFF
--- a/docs/reference/cli/grafanactl_config_view.md
+++ b/docs/reference/cli/grafanactl_config_view.md
@@ -18,7 +18,7 @@ grafanactl config view [flags]
 ```
   -h, --help            help for view
       --minify          Remove all information not used by current-context from the output
-  -o, --output string   Output format. One of: yaml, json (default "yaml")
+  -o, --output string   Output format. One of: json, yaml (default "yaml")
       --raw             Display sensitive information
 ```
 


### PR DESCRIPTION
This should avoid "random" changes when running `make cli-reference` (and it should also prevent failing the CI pipelines because of this randomly induced drift in the generated CLI reference)