### PR TITLE
Support writing pulled resources to disk

### DIFF
--- a/cmd/config/command.go
+++ b/cmd/config/command.go
@@ -177,7 +177,7 @@ func viewCmd(logger logging.Logger, configOpts *Options) *cobra.Command {
 				}
 			}
 
-			if err := opts.IO.Format(cfg, cmd.OutOrStdout()); err != nil {
+			if err := opts.IO.Format(cmd.OutOrStdout(), cfg); err != nil {
 				return err
 			}
 

--- a/internal/format/formatters.go
+++ b/internal/format/formatters.go
@@ -1,0 +1,35 @@
+package format
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+
+	"github.com/goccy/go-yaml"
+)
+
+type Formatter func(output io.Writer, resource any) error
+
+func YAML(output io.Writer, input any) error {
+	encoder := yaml.NewEncoder(
+		output,
+		yaml.Indent(2),
+		yaml.IndentSequence(true),
+		yaml.UseJSONMarshaler(),
+		yaml.CustomMarshaler[[]byte](func(data []byte) ([]byte, error) {
+			dst := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+			base64.StdEncoding.Encode(dst, data)
+
+			return dst, nil
+		}),
+	)
+
+	return encoder.Encode(input)
+}
+
+func JSON(output io.Writer, input any) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(input)
+}

--- a/internal/resources/writer.go
+++ b/internal/resources/writer.go
@@ -1,0 +1,113 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafanactl/internal/format"
+	"github.com/grafana/grafanactl/internal/logs"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type FileNamer func(resource unstructured.Unstructured) (string, error)
+
+// GroupResourcesByKind organizes resources by kind, writing resources in a
+// folder named after their kind.
+// File names are generated as follows: `{Kind}/{Name}.{extension}`.
+func GroupResourcesByKind(extension string) FileNamer {
+	return func(resource unstructured.Unstructured) (string, error) {
+		if resource.GetName() == "" {
+			return "", errors.New("resource has no name")
+		}
+
+		return filepath.Join(resource.GetKind(), resource.GetName()+"."+extension), nil
+	}
+}
+
+type FSWriter struct {
+	Logger logging.Logger
+	// Directory on the filesystem where resources should be written.
+	Directory string
+	// Namer is a function mapping a resource to a path on the filesystem
+	// (relative to Directory).
+	// The naming strategy used here directly controls the file hierarchy created
+	// by FSWriter.
+	// Note: the path should contain an extension.
+	Namer FileNamer
+	// Formatter is the function used to marshal a given resource to the
+	// desired output format.
+	Formatter       format.Formatter
+	ContinueOnError bool
+}
+
+func (writer *FSWriter) Write(resources *unstructured.UnstructuredList) error {
+	if resources == nil || len(resources.Items) == 0 {
+		return nil
+	}
+
+	logger := writer.Logger.With(slog.String("directory", writer.Directory))
+	logger.Debug("Writing resources", slog.Int("resources", len(resources.Items)))
+
+	// Create the directory if it doesn't exist
+	if err := ensureDirectoryExists(writer.Directory); err != nil {
+		return err
+	}
+
+	for _, resource := range resources.Items {
+		err := writer.writeSingle(resource)
+		if err != nil && writer.ContinueOnError {
+			logger.Warn("could not write resource: skipping", slog.String("kind", resource.GetKind()), logs.Err(err))
+			continue
+		} else if err != nil && !writer.ContinueOnError {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (writer *FSWriter) writeSingle(resource unstructured.Unstructured) error {
+	filename, err := writer.Namer(resource)
+	if err != nil {
+		return fmt.Errorf("could not generate resource path: %w", err)
+	}
+
+	fullFileName := filepath.Join(writer.Directory, filename)
+	if err := ensureDirectoryExists(filepath.Dir(fullFileName)); err != nil {
+		return fmt.Errorf("could ensure resource directory exists: %w", err)
+	}
+
+	file, err := os.OpenFile(fullFileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("could open resource file: %w", err)
+	}
+	defer file.Close()
+
+	// MarshalJSON() methods for [unstructured.UnstructuredList] and
+	// [unstructured.Unstructured] types are defined on pointer receivers,
+	// so we need to make sure we dereference `resource` before formatting it.
+	if err := writer.Formatter(file, &resource); err != nil {
+		return fmt.Errorf("could write resource: %w", err)
+	}
+
+	return nil
+}
+
+func ensureDirectoryExists(directory string) error {
+	if _, err := os.Stat(directory); err != nil {
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(directory, 0755)
+			if err != nil {
+				return err
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/internal/resources/writer_test.go
+++ b/internal/resources/writer_test.go
@@ -1,0 +1,130 @@
+package resources_test
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafanactl/internal/format"
+	"github.com/grafana/grafanactl/internal/resources"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestFSWriter_Write(t *testing.T) {
+	req := require.New(t)
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	writer := resources.FSWriter{
+		Logger:    &logging.NoOpLogger{},
+		Directory: outputDir,
+		Formatter: format.YAML,
+		Namer: func(resource unstructured.Unstructured) (string, error) {
+			return resource.GetName() + ".yaml", nil
+		},
+	}
+
+	err := writer.Write(testResources())
+	req.NoError(err)
+
+	req.FileExists(filepath.Join(outputDir, "folder-uid.yaml"))
+	req.FileExists(filepath.Join(outputDir, "sa-uid.yaml"))
+}
+
+func TestFSWriter_Write_continueOnError(t *testing.T) {
+	req := require.New(t)
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	writer := resources.FSWriter{
+		Logger:          &logging.NoOpLogger{},
+		Directory:       outputDir,
+		Formatter:       format.YAML,
+		ContinueOnError: true,
+		Namer: func(resource unstructured.Unstructured) (string, error) {
+			if resource.GetKind() == "Folder" {
+				return "", errors.New("woops, folders are causing some trouble :(")
+			}
+			return resource.GetName() + ".yaml", nil
+		},
+	}
+
+	err := writer.Write(testResources())
+	req.NoError(err)
+
+	req.NoFileExists(filepath.Join(outputDir, "folder-uid.yaml"), "not created because of an error somewhere")
+	req.FileExists(filepath.Join(outputDir, "sa-uid.yaml"), "continued on error and got created")
+}
+
+func TestFSWriter_Write_groupedByKind(t *testing.T) {
+	req := require.New(t)
+	outputDir := filepath.Join(t.TempDir(), "output")
+
+	writer := resources.FSWriter{
+		Logger:    &logging.NoOpLogger{},
+		Directory: outputDir,
+		Formatter: format.JSON,
+		Namer:     resources.GroupResourcesByKind("json"),
+	}
+
+	err := writer.Write(testResources())
+	req.NoError(err)
+
+	req.FileExists(filepath.Join(outputDir, "Folder", "folder-uid.json"))
+	req.FileExists(filepath.Join(outputDir, "ServiceAccount", "sa-uid.json"))
+}
+
+func TestFSWriter_Write_doesNothingWithNoResources(t *testing.T) {
+	req := require.New(t)
+	outputDir := filepath.Join(t.TempDir(), "output")
+	input := &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{},
+	}
+
+	writer := resources.FSWriter{
+		Logger:    &logging.NoOpLogger{},
+		Directory: outputDir,
+		Formatter: format.YAML,
+		Namer: func(resource unstructured.Unstructured) (string, error) {
+			return resource.GetName() + ".yaml", nil
+		},
+	}
+
+	err := writer.Write(input)
+	req.NoError(err)
+
+	req.NoDirExists(outputDir)
+}
+
+func testResources() *unstructured.UnstructuredList {
+	return &unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]any{
+					"apiVersion": "folder.grafana.app/v0alpha1",
+					"kind":       "Folder",
+					"metadata": map[string]any{
+						"name":      "folder-uid",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"title": "Test folder",
+					},
+				},
+			},
+			{
+				Object: map[string]any{
+					"apiVersion": "iam.grafana.app/v0alpha1",
+					"kind":       "ServiceAccount",
+					"metadata": map[string]any{
+						"name":      "sa-uid",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"title": "editor",
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Part of #20

This PR adds support for actually writing pulled resources to disk.

The feature is relatively bare-bones for now as only the destination directory and output format can be configured.

Resources will be grouped by "kind" on disk:

```
out
├── Dashboard
│   ├── addn8zk.yaml
│   └── adgnd6g.yaml
├── FeatureToggles
│   └── startup.yaml
├── Folder
│   └── dehva11ya0v7kc.yaml
├── Receiver
│   └── Z3JhZmFuYS1kZWZhdWx0LWVtYWls.yaml
├── RoutingTree
│   └── user-defined.yaml
├── ServiceAccount
│   └── dehjf368dxjwgf.yaml
└── TemplateGroup
    └── __default__.yaml
```

**Note:** I noticed a few issues while implementing this feature

* when pulling all resources, duplicates are returned
* `grafanactl resources pull dashboard` works as intended, but `grafanactl resources pull Dashboard` fails (also applies to other resources)
* `grafanactl resources pull` generates a lot of warnings for resources that can't be pulled for various reasons