### PR TITLE
Display a somewhat clean error message for authentication issues when…

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -77,7 +77,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Log HTTP requests/responses at debug level
 	r.Use(middleware.RequestLogger(&middleware.DefaultLogFormatter{
-		Logger:  logs.DecorateAtLevel(logging.FromContext(ctx), slog.LevelDebug),
+		Logger:  logs.DecorateAtLevel(logging.FromContext(ctx), slog.LevelInfo),
 		NoColor: s.config.NoColor,
 	}))
 	// Inject the logger in HTTP requests context


### PR DESCRIPTION
… using `grafanactl resources serve`

Instead of having a dashboard with broken panels everywhere, let's display an error message indicating that authentication isn't configured properly.

Once we have something like https://github.com/grafana/grafanactl/pull/23 merged, we can also mention it to help debugging the issue.