### PR TITLE
Hardcode cli name in usage example docs

### DIFF
--- a/cmd/config/command.go
+++ b/cmd/config/command.go
@@ -3,8 +3,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"os"
-	"path"
 	"strings"
 
 	"github.com/caarlos0/env/v11"
@@ -15,9 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
-
-//nolint:gochecknoglobals
-var binaryName = path.Base(os.Args[0])
 
 type Options struct {
 	ConfigFile string
@@ -165,7 +160,7 @@ func viewCmd(configOpts *Options) *cobra.Command {
 		Use:     "view",
 		Args:    cobra.NoArgs,
 		Short:   "Display the current configuration",
-		Example: "\n\t" + binaryName + " config view",
+		Example: "\n\tgrafanactl config view",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.Validate(); err != nil {
 				return err
@@ -209,7 +204,7 @@ func currentContextCmd(configOpts *Options) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Short:   "Display the current context name",
 		Long:    "Display the current context name.",
-		Example: "\n\t" + binaryName + " config current-context",
+		Example: "\n\tgrafanactl config current-context",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := configOpts.loadConfigTolerant(cmd.Context())
 			if err != nil {
@@ -231,7 +226,7 @@ func checkCmd(configOpts *Options) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Short:   "Check the current configuration for issues",
 		Long:    "Check the current configuration for issues.",
-		Example: "\n\t" + binaryName + " config check",
+		Example: "\n\tgrafanactl config check",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg, err := configOpts.loadConfigTolerant(cmd.Context())
 			if err != nil {
@@ -306,7 +301,7 @@ func useContextCmd(configOpts *Options) *cobra.Command {
 		Aliases: []string{"use"},
 		Short:   "Set the current context",
 		Long:    "Set the current context and updates the configuration file.",
-		Example: "\n\t" + binaryName + " config use-context dev-instance",
+		Example: "\n\tgrafanactl config use-context dev-instance",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := configOpts.loadConfigTolerant(cmd.Context())
 			if err != nil {
@@ -341,12 +336,12 @@ func setCmd(configOpts *Options) *cobra.Command {
 PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either represent a field or a map entry.
 
 PROPERTY_VALUE is the new value to set.`,
-		Example: fmt.Sprintf(`
+		Example: `
 	# Set the "server" field on the "dev-instance" context to "https://grafana-dev.example"
-	%[1]s config set contexts.dev-instance.grafana.server https://grafana-dev.example
+	grafanactl config set contexts.dev-instance.grafana.server https://grafana-dev.example
 
 	# Disable the validation of the server's SSL certificate in the "dev-instance" context
-	%[1]s config set contexts.dev-instance.grafana.insecure-skip-tls-verify true`, binaryName),
+	grafanactl config set contexts.dev-instance.grafana.insecure-skip-tls-verify true`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := configOpts.loadConfigTolerant(cmd.Context())
 			if err != nil {
@@ -372,12 +367,12 @@ func unsetCmd(configOpts *Options) *cobra.Command {
 		Long: `Unset an single value in a configuration file.
 
 PROPERTY_NAME is a dot-delimited reference to the value to unset. It can either represent a field or a map entry.`,
-		Example: fmt.Sprintf(`
+		Example: `
 	# Unset the "foo" context
-	%[1]s config unset contexts.foo
+	grafanactl config unset contexts.foo
 
 	# Unset the "insecure-skip-tls-verify" flag in the "dev-instance" context
-	%[1]s config unset contexts.dev-instance.grafana.insecure-skip-tls-verify`, binaryName),
+	grafanactl config unset contexts.dev-instance.grafana.insecure-skip-tls-verify`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := configOpts.loadConfigTolerant(cmd.Context())
 			if err != nil {

--- a/cmd/resources/command.go
+++ b/cmd/resources/command.go
@@ -1,15 +1,9 @@
 package resources
 
 import (
-	"os"
-	"path"
-
 	cmdconfig "github.com/grafana/grafanactl/cmd/config"
 	"github.com/spf13/cobra"
 )
-
-//nolint:gochecknoglobals
-var binaryName = path.Base(os.Args[0])
 
 func Command() *cobra.Command {
 	configOpts := &cmdconfig.Options{}

--- a/cmd/resources/get.go
+++ b/cmd/resources/get.go
@@ -52,44 +52,44 @@ func getCmd(configOpts *cmdconfig.Options) *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		Short: "Get resources from Grafana",
 		Long:  "Get resources from Grafana using a specific format. See examples below for more details.",
-		Example: fmt.Sprintf(`
+		Example: `
 	# Everything:
 
-	%[1]s resources get dashboards/foo
+	grafanactl resources get dashboards/foo
 
 	# All instances for a given kind(s):
 
-	%[1]s resources get dashboards
-	%[1]s resources get dashboards folders
+	grafanactl resources get dashboards
+	grafanactl resources get dashboards folders
 
 	# Single resource kind, one or more resource instances:
 
-	%[1]s resources get dashboards/foo
-	%[1]s resources get dashboards/foo,bar
+	grafanactl resources get dashboards/foo
+	grafanactl resources get dashboards/foo,bar
 
 	# Single resource kind, long kind format:
 
-	%[1]s resources get dashboard.dashboards/foo
-	%[1]s resources get dashboard.dashboards/foo,bar
+	grafanactl resources get dashboard.dashboards/foo
+	grafanactl resources get dashboard.dashboards/foo,bar
 
 	# Single resource kind, long kind format with version:
 
-	%[1]s resources get dashboards.v1alpha1.dashboard.grafana.app/foo
-	%[1]s resources get dashboards.v1alpha1.dashboard.grafana.app/foo,bar
+	grafanactl resources get dashboards.v1alpha1.dashboard.grafana.app/foo
+	grafanactl resources get dashboards.v1alpha1.dashboard.grafana.app/foo,bar
 
 	# Multiple resource kinds, one or more resource instances:
 
-	%[1]s resources get dashboards/foo folders/qux
-	%[1]s resources get dashboards/foo,bar folders/qux,quux
+	grafanactl resources get dashboards/foo folders/qux
+	grafanactl resources get dashboards/foo,bar folders/qux,quux
 
 	# Multiple resource kinds, long kind format:
 
-	%[1]s resources get dashboard.dashboards/foo folder.folders/qux
-	%[1]s resources get dashboard.dashboards/foo,bar folder.folders/qux,quux
+	grafanactl resources get dashboard.dashboards/foo folder.folders/qux
+	grafanactl resources get dashboard.dashboards/foo,bar folder.folders/qux,quux
 
 	# Multiple resource kinds, long kind format with version:
 
-	%[1]s resources get dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux`, binaryName),
+	grafanactl resources get dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/cmd/resources/list.go
+++ b/cmd/resources/list.go
@@ -15,9 +15,9 @@ func listCmd(configOpts *cmdconfig.Options) *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "List available Grafana API resources",
 		Long:  "List available Grafana API resources.",
-		Example: fmt.Sprintf(`
-	%[1]s resources list
-`, binaryName),
+		Example: `
+	grafanactl resources list
+`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 

--- a/cmd/resources/pull.go
+++ b/cmd/resources/pull.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 
 	cmdconfig "github.com/grafana/grafanactl/cmd/config"
 	cmdio "github.com/grafana/grafanactl/cmd/io"
@@ -49,44 +48,44 @@ func pullCmd(configOpts *cmdconfig.Options) *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		Short: "Pull resources from Grafana",
 		Long:  "Pull resources from Grafana using a specific format. See examples below for more details.",
-		Example: fmt.Sprintf(`
+		Example: `
 	# Everything:
 
-	%[1]s resources pull
+	grafanactl resources pull
 
 	# All instances for a given kind(s):
 
-	%[1]s resources pull dashboards
-	%[1]s resources pull dashboards folders
+	grafanactl resources pull dashboards
+	grafanactl resources pull dashboards folders
 
 	# Single resource kind, one or more resource instances:
 
-	%[1]s resources pull dashboards/foo
-	%[1]s resources pull dashboards/foo,bar
+	grafanactl resources pull dashboards/foo
+	grafanactl resources pull dashboards/foo,bar
 
 	# Single resource kind, long kind format:
 
-	%[1]s resources pull dashboard.dashboards/foo
-	%[1]s resources pull dashboard.dashboards/foo,bar
+	grafanactl resources pull dashboard.dashboards/foo
+	grafanactl resources pull dashboard.dashboards/foo,bar
 
 	# Single resource kind, long kind format with version:
 
-	%[1]s resources pull dashboards.v1alpha1.dashboard.grafana.app/foo
-	%[1]s resources pull dashboards.v1alpha1.dashboard.grafana.app/foo,bar
+	grafanactl resources pull dashboards.v1alpha1.dashboard.grafana.app/foo
+	grafanactl resources pull dashboards.v1alpha1.dashboard.grafana.app/foo,bar
 
 	# Multiple resource kinds, one or more resource instances:
 
-	%[1]s resources pull dashboards/foo folders/qux
-	%[1]s resources pull dashboards/foo,bar folders/qux,quux
+	grafanactl resources pull dashboards/foo folders/qux
+	grafanactl resources pull dashboards/foo,bar folders/qux,quux
 
 	# Multiple resource kinds, long kind format:
 
-	%[1]s resources pull dashboard.dashboards/foo folder.folders/qux
-	%[1]s resources pull dashboard.dashboards/foo,bar folder.folders/qux,quux
+	grafanactl resources pull dashboard.dashboards/foo folder.folders/qux
+	grafanactl resources pull dashboard.dashboards/foo,bar folder.folders/qux,quux
 
 	# Multiple resource kinds, long kind format with version:
 
-	%[1]s resources pull dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux`, binaryName),
+	grafanactl resources pull dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/cmd/resources/push.go
+++ b/cmd/resources/push.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"errors"
-	"fmt"
 
 	cmdconfig "github.com/grafana/grafanactl/cmd/config"
 	"github.com/grafana/grafanactl/internal/format"
@@ -47,44 +46,44 @@ func pushCmd(configOpts *cmdconfig.Options) *cobra.Command {
 		Args:  cobra.ArbitraryArgs,
 		Short: "Push resources to Grafana",
 		Long:  "Push resources to Grafana using a specific format. See examples below for more details.",
-		Example: fmt.Sprintf(`
+		Example: `
 	# Everything:
 
-	%[1]s resources push
+	grafanactl resources push
 
 	# All instances for a given kind(s):
 
-	%[1]s resources push dashboards
-	%[1]s resources push dashboards folders
+	grafanactl resources push dashboards
+	grafanactl resources push dashboards folders
 
 	# Single resource kind, one or more resource instances:
 
-	%[1]s resources push dashboards/foo
-	%[1]s resources push dashboards/foo,bar
+	grafanactl resources push dashboards/foo
+	grafanactl resources push dashboards/foo,bar
 
 	# Single resource kind, long kind format:
 
-	%[1]s resources push dashboard.dashboards/foo
-	%[1]s resources push dashboard.dashboards/foo,bar
+	grafanactl resources push dashboard.dashboards/foo
+	grafanactl resources push dashboard.dashboards/foo,bar
 
 	# Single resource kind, long kind format with version:
 
-	%[1]s resources push dashboards.v1alpha1.dashboard.grafana.app/foo
-	%[1]s resources push dashboards.v1alpha1.dashboard.grafana.app/foo,bar
+	grafanactl resources push dashboards.v1alpha1.dashboard.grafana.app/foo
+	grafanactl resources push dashboards.v1alpha1.dashboard.grafana.app/foo,bar
 
 	# Multiple resource kinds, one or more resource instances:
 
-	%[1]s resources push dashboards/foo folders/qux
-	%[1]s resources push dashboards/foo,bar folders/qux,quux
+	grafanactl resources push dashboards/foo folders/qux
+	grafanactl resources push dashboards/foo,bar folders/qux,quux
 
 	# Multiple resource kinds, long kind format:
 
-	%[1]s resources push dashboard.dashboards/foo folder.folders/qux
-	%[1]s resources push dashboard.dashboards/foo,bar folder.folders/qux,quux
+	grafanactl resources push dashboard.dashboards/foo folder.folders/qux
+	grafanactl resources push dashboard.dashboards/foo,bar folder.folders/qux,quux
 
 	# Multiple resource kinds, long kind format with version:
 
-	%[1]s resources push dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux`, binaryName),
+	grafanactl resources push dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/cmd/resources/serve.go
+++ b/cmd/resources/serve.go
@@ -68,17 +68,17 @@ Note on NFS/SMB support for --watch: fsnotify requires support from underlying
 OS to work. The current NFS and SMB protocols does not provide network level
 support for file notifications.
 `,
-		Example: fmt.Sprintf(`
+		Example: `
 	# Serve resources from a directory:
-	%[1]s resources serve ./resources
+	grafanactl resources serve ./resources
 
 	# Serve resources from a directory and watch for changes:
-	%[1]s resources serve ./resources --watch ./resources
+	grafanactl resources serve ./resources --watch ./resources
 
 	# Serve resources from a script that outputs a JSON resource and watch for changes:
 	# Note: the Grafana Foundation SDK can be used to generate dashboards (https://grafana.github.io/grafana-foundation-sdk/)
-	%[1]s resources serve --script 'go run dashboard-generator/*.go' --watch ./dashboard-generator --script-format json
-`, binaryName),
+	grafanactl resources serve --script 'go run dashboard-generator/*.go' --watch ./dashboard-generator --script-format json
+`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
 				return err

--- a/docs/reference/cli/grafanactl_config_check.md
+++ b/docs/reference/cli/grafanactl_config_check.md
@@ -14,7 +14,7 @@ grafanactl config check [flags]
 
 ```
 
-	main config check
+	grafanactl config check
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_config_current-context.md
+++ b/docs/reference/cli/grafanactl_config_current-context.md
@@ -14,7 +14,7 @@ grafanactl config current-context [flags]
 
 ```
 
-	main config current-context
+	grafanactl config current-context
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_config_set.md
+++ b/docs/reference/cli/grafanactl_config_set.md
@@ -19,10 +19,10 @@ grafanactl config set PROPERTY_NAME PROPERTY_VALUE [flags]
 ```
 
 	# Set the "server" field on the "dev-instance" context to "https://grafana-dev.example"
-	main config set contexts.dev-instance.grafana.server https://grafana-dev.example
+	grafanactl config set contexts.dev-instance.grafana.server https://grafana-dev.example
 
 	# Disable the validation of the server's SSL certificate in the "dev-instance" context
-	main config set contexts.dev-instance.grafana.insecure-skip-tls-verify true
+	grafanactl config set contexts.dev-instance.grafana.insecure-skip-tls-verify true
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_config_unset.md
+++ b/docs/reference/cli/grafanactl_config_unset.md
@@ -17,10 +17,10 @@ grafanactl config unset PROPERTY_NAME [flags]
 ```
 
 	# Unset the "foo" context
-	main config unset contexts.foo
+	grafanactl config unset contexts.foo
 
 	# Unset the "insecure-skip-tls-verify" flag in the "dev-instance" context
-	main config unset contexts.dev-instance.grafana.insecure-skip-tls-verify
+	grafanactl config unset contexts.dev-instance.grafana.insecure-skip-tls-verify
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_config_use-context.md
+++ b/docs/reference/cli/grafanactl_config_use-context.md
@@ -14,7 +14,7 @@ grafanactl config use-context CONTEXT_NAME [flags]
 
 ```
 
-	main config use-context dev-instance
+	grafanactl config use-context dev-instance
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_config_view.md
+++ b/docs/reference/cli/grafanactl_config_view.md
@@ -10,7 +10,7 @@ grafanactl config view [flags]
 
 ```
 
-	main config view
+	grafanactl config view
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_resources_get.md
+++ b/docs/reference/cli/grafanactl_resources_get.md
@@ -16,41 +16,41 @@ grafanactl resources get [RESOURCE_SELECTOR]... [flags]
 
 	# Everything:
 
-	main resources get dashboards/foo
+	grafanactl resources get dashboards/foo
 
 	# All instances for a given kind(s):
 
-	main resources get dashboards
-	main resources get dashboards folders
+	grafanactl resources get dashboards
+	grafanactl resources get dashboards folders
 
 	# Single resource kind, one or more resource instances:
 
-	main resources get dashboards/foo
-	main resources get dashboards/foo,bar
+	grafanactl resources get dashboards/foo
+	grafanactl resources get dashboards/foo,bar
 
 	# Single resource kind, long kind format:
 
-	main resources get dashboard.dashboards/foo
-	main resources get dashboard.dashboards/foo,bar
+	grafanactl resources get dashboard.dashboards/foo
+	grafanactl resources get dashboard.dashboards/foo,bar
 
 	# Single resource kind, long kind format with version:
 
-	main resources get dashboards.v1alpha1.dashboard.grafana.app/foo
-	main resources get dashboards.v1alpha1.dashboard.grafana.app/foo,bar
+	grafanactl resources get dashboards.v1alpha1.dashboard.grafana.app/foo
+	grafanactl resources get dashboards.v1alpha1.dashboard.grafana.app/foo,bar
 
 	# Multiple resource kinds, one or more resource instances:
 
-	main resources get dashboards/foo folders/qux
-	main resources get dashboards/foo,bar folders/qux,quux
+	grafanactl resources get dashboards/foo folders/qux
+	grafanactl resources get dashboards/foo,bar folders/qux,quux
 
 	# Multiple resource kinds, long kind format:
 
-	main resources get dashboard.dashboards/foo folder.folders/qux
-	main resources get dashboard.dashboards/foo,bar folder.folders/qux,quux
+	grafanactl resources get dashboard.dashboards/foo folder.folders/qux
+	grafanactl resources get dashboard.dashboards/foo,bar folder.folders/qux,quux
 
 	# Multiple resource kinds, long kind format with version:
 
-	main resources get dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux
+	grafanactl resources get dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_resources_list.md
+++ b/docs/reference/cli/grafanactl_resources_list.md
@@ -14,7 +14,7 @@ grafanactl resources list [flags]
 
 ```
 
-	main resources list
+	grafanactl resources list
 
 ```
 

--- a/docs/reference/cli/grafanactl_resources_pull.md
+++ b/docs/reference/cli/grafanactl_resources_pull.md
@@ -16,41 +16,41 @@ grafanactl resources pull [RESOURCE_SELECTOR]... [flags]
 
 	# Everything:
 
-	main resources pull
+	grafanactl resources pull
 
 	# All instances for a given kind(s):
 
-	main resources pull dashboards
-	main resources pull dashboards folders
+	grafanactl resources pull dashboards
+	grafanactl resources pull dashboards folders
 
 	# Single resource kind, one or more resource instances:
 
-	main resources pull dashboards/foo
-	main resources pull dashboards/foo,bar
+	grafanactl resources pull dashboards/foo
+	grafanactl resources pull dashboards/foo,bar
 
 	# Single resource kind, long kind format:
 
-	main resources pull dashboard.dashboards/foo
-	main resources pull dashboard.dashboards/foo,bar
+	grafanactl resources pull dashboard.dashboards/foo
+	grafanactl resources pull dashboard.dashboards/foo,bar
 
 	# Single resource kind, long kind format with version:
 
-	main resources pull dashboards.v1alpha1.dashboard.grafana.app/foo
-	main resources pull dashboards.v1alpha1.dashboard.grafana.app/foo,bar
+	grafanactl resources pull dashboards.v1alpha1.dashboard.grafana.app/foo
+	grafanactl resources pull dashboards.v1alpha1.dashboard.grafana.app/foo,bar
 
 	# Multiple resource kinds, one or more resource instances:
 
-	main resources pull dashboards/foo folders/qux
-	main resources pull dashboards/foo,bar folders/qux,quux
+	grafanactl resources pull dashboards/foo folders/qux
+	grafanactl resources pull dashboards/foo,bar folders/qux,quux
 
 	# Multiple resource kinds, long kind format:
 
-	main resources pull dashboard.dashboards/foo folder.folders/qux
-	main resources pull dashboard.dashboards/foo,bar folder.folders/qux,quux
+	grafanactl resources pull dashboard.dashboards/foo folder.folders/qux
+	grafanactl resources pull dashboard.dashboards/foo,bar folder.folders/qux,quux
 
 	# Multiple resource kinds, long kind format with version:
 
-	main resources pull dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux
+	grafanactl resources pull dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_resources_push.md
+++ b/docs/reference/cli/grafanactl_resources_push.md
@@ -16,41 +16,41 @@ grafanactl resources push [RESOURCE_SELECTOR]... [flags]
 
 	# Everything:
 
-	main resources push
+	grafanactl resources push
 
 	# All instances for a given kind(s):
 
-	main resources push dashboards
-	main resources push dashboards folders
+	grafanactl resources push dashboards
+	grafanactl resources push dashboards folders
 
 	# Single resource kind, one or more resource instances:
 
-	main resources push dashboards/foo
-	main resources push dashboards/foo,bar
+	grafanactl resources push dashboards/foo
+	grafanactl resources push dashboards/foo,bar
 
 	# Single resource kind, long kind format:
 
-	main resources push dashboard.dashboards/foo
-	main resources push dashboard.dashboards/foo,bar
+	grafanactl resources push dashboard.dashboards/foo
+	grafanactl resources push dashboard.dashboards/foo,bar
 
 	# Single resource kind, long kind format with version:
 
-	main resources push dashboards.v1alpha1.dashboard.grafana.app/foo
-	main resources push dashboards.v1alpha1.dashboard.grafana.app/foo,bar
+	grafanactl resources push dashboards.v1alpha1.dashboard.grafana.app/foo
+	grafanactl resources push dashboards.v1alpha1.dashboard.grafana.app/foo,bar
 
 	# Multiple resource kinds, one or more resource instances:
 
-	main resources push dashboards/foo folders/qux
-	main resources push dashboards/foo,bar folders/qux,quux
+	grafanactl resources push dashboards/foo folders/qux
+	grafanactl resources push dashboards/foo,bar folders/qux,quux
 
 	# Multiple resource kinds, long kind format:
 
-	main resources push dashboard.dashboards/foo folder.folders/qux
-	main resources push dashboard.dashboards/foo,bar folder.folders/qux,quux
+	grafanactl resources push dashboard.dashboards/foo folder.folders/qux
+	grafanactl resources push dashboard.dashboards/foo,bar folder.folders/qux,quux
 
 	# Multiple resource kinds, long kind format with version:
 
-	main resources push dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux
+	grafanactl resources push dashboards.v1alpha1.dashboard.grafana.app/foo folders.v1alpha1.folder.grafana.app/qux
 ```
 
 ### Options

--- a/docs/reference/cli/grafanactl_resources_serve.md
+++ b/docs/reference/cli/grafanactl_resources_serve.md
@@ -27,14 +27,14 @@ grafanactl resources serve [RESOURCE_DIR]... [flags]
 ```
 
 	# Serve resources from a directory:
-	main resources serve ./resources
+	grafanactl resources serve ./resources
 
 	# Serve resources from a directory and watch for changes:
-	main resources serve ./resources --watch ./resources
+	grafanactl resources serve ./resources --watch ./resources
 
 	# Serve resources from a script that outputs a JSON resource and watch for changes:
 	# Note: the Grafana Foundation SDK can be used to generate dashboards (https://grafana.github.io/grafana-foundation-sdk/)
-	main resources serve --script 'go run dashboard-generator/*.go' --watch ./dashboard-generator --script-format json
+	grafanactl resources serve --script 'go run dashboard-generator/*.go' --watch ./dashboard-generator --script-format json
 
 ```
 


### PR DESCRIPTION
Once again: trying to be smart and dynamically get the name of the binary backfired. Depending on how the CLI reference docs are generated, we end up with an incorrect name.

Instead, let's hardcode this value since it's not bound to change.