### PR TITLE
Fix grafanactl config set for int valeus

### DIFF
--- a/internal/config/editor.go
+++ b/internal/config/editor.go
@@ -20,6 +20,7 @@ func UnsetValue[V any](input *V, path string) error {
 	return updateValue(reflect.ValueOf(input), pathParts, "", true)
 }
 
+//nolint:gocyclo
 func updateValue(input reflect.Value, path []string, value string, unset bool) error {
 	// Just don't want to deal with pointers later.
 	actualInput := input
@@ -132,6 +133,22 @@ func updateValue(input reflect.Value, path []string, value string, unset bool) e
 		}
 
 		actualInput.SetBool(boolValue)
+	case reflect.Int64:
+		if len(path) != 0 {
+			return fmt.Errorf("more steps after int64: %s", strings.Join(path, "."))
+		}
+
+		if unset {
+			actualInput.SetInt(0)
+			return nil
+		}
+
+		intValue, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return fmt.Errorf("can not parse value as int64: %s", value)
+		}
+
+		actualInput.SetInt(intValue)
 	default:
 		return fmt.Errorf("unhandled kind %v", actualInput.Kind())
 	}

--- a/internal/config/editor_test.go
+++ b/internal/config/editor_test.go
@@ -80,6 +80,19 @@ func Test_SetValue(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "int64 in new context",
+			input: config.Config{},
+			path:  "contexts.new.grafana.org-id",
+			value: "1",
+			expectedOutput: config.Config{
+				Contexts: map[string]*config.Context{
+					"new": {
+						Grafana: &config.GrafanaConfig{OrgID: 1},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
The config editor didn't support changing the value of config fields defined as int64, preventing us from setting `org-id` or `stack-id` via the CLI.