### PR TITLE
Better errors in `resources serve`

### DIFF
--- a/internal/server/grafana/requests.go
+++ b/internal/server/grafana/requests.go
@@ -50,6 +50,7 @@ func AuthenticateAndProxyHandler(cfg *config.GrafanaConfig) http.HandlerFunc {
 			httputils.Error(r, w, http.StatusText(http.StatusInternalServerError), err, http.StatusInternalServerError)
 			return
 		}
+		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusFound {
 			w.WriteHeader(http.StatusUnauthorized)

--- a/internal/server/watch/watcher.go
+++ b/internal/server/watch/watcher.go
@@ -78,8 +78,8 @@ func (w *Watcher) Watch() {
 
 				w.logger.Debug("event:", slog.Any("event", event))
 				if event.Has(fsnotify.Create) || event.Has(fsnotify.Write) {
-					w.callback(event.Name)
 					w.logger.Debug("detected file change:", slog.String("file", event.Name), slog.String("op", event.Op.String()))
+					w.callback(event.Name)
 				}
 			case err, ok := <-w.notifier.Errors:
 				if !ok {


### PR DESCRIPTION
This PR is a small QoL improvement: whenever `grafanactl resources serve` is used with the `--script` flag and the given script fails, we log its stderr to allow debugging.

However, the output written on stderr by the script is often multi-line (stacktrace, panics, ...).
To make it more easily readable, I include stderr's content in a "detailed error":

![Screenshot From 2025-04-16 01-11-42](https://github.com/user-attachments/assets/b449b292-324f-4cbe-a23f-656103a78e03)
