### PR TITLE
`resources edit` command

### DIFF
--- a/cmd/resources/command.go
+++ b/cmd/resources/command.go
@@ -19,6 +19,7 @@ TODO: more information.
 
 	configOpts.BindFlags(cmd.PersistentFlags())
 
+	cmd.AddCommand(editCmd(configOpts))
 	cmd.AddCommand(getCmd(configOpts))
 	cmd.AddCommand(listCmd(configOpts))
 	cmd.AddCommand(pullCmd(configOpts))

--- a/cmd/resources/edit.go
+++ b/cmd/resources/edit.go
@@ -1,0 +1,148 @@
+package resources
+
+import (
+	"bytes"
+
+	cmdconfig "github.com/grafana/grafanactl/cmd/config"
+	cmdio "github.com/grafana/grafanactl/cmd/io"
+	"github.com/grafana/grafanactl/internal/format"
+	"github.com/grafana/grafanactl/internal/resources"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type editOpts struct {
+	IO cmdio.Options
+}
+
+func (opts *editOpts) setup(flags *pflag.FlagSet) {
+	// Bind all the flags
+	opts.IO.BindFlags(flags)
+}
+
+func (opts *editOpts) Validate() error {
+	if err := opts.IO.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func editCmd(configOpts *cmdconfig.Options) *cobra.Command {
+	opts := &editOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "edit RESOURCE_SELECTOR",
+		Args:  cobra.ExactArgs(1),
+		Short: "Edit resources from Grafana",
+		Long: `Edit resources from Grafana using the default editor.
+
+This command allows the edition of any resource that can be accessed by this CLI tool.
+
+It will open the default editor as configured by the EDITOR environment variable, or fall back to 'vi' for Linux or 'notepad' for Windows.
+The editor will be started in the shell set by the SHELL environment variable. If undefined, '/bin/bash' is used for Linux or 'cmd' for Windows.
+
+The edition will be cancelled if no changes are written to the file or if the file after edition is empty.
+`,
+		Example: `
+	# Editing a dashboard
+	grafanactl resources dashboard/foo
+
+	# Editing a dashboard in JSON
+	grafanactl resources -o json dashboard/foo
+
+	# Using an alternative editor
+	EDITOR=nvim grafanactl resources dashboard/foo
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			edit := editorFromEnv()
+
+			cfg, err := configOpts.LoadRESTConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			pusher, err := resources.NewPusher(ctx, cfg)
+			if err != nil {
+				return err
+			}
+
+			reader := resources.FSReader{
+				Decoders:           format.Codecs(),
+				MaxConcurrentReads: 1,
+				StopOnError:        true,
+			}
+
+			// Fetch the resource
+			res, err := fetchResources(ctx, fetchRequest{
+				Config:             cfg,
+				StopOnError:        true,
+				ExpectSingleTarget: true,
+			}, args)
+			if err != nil {
+				return err
+			}
+
+			codec, err := opts.IO.Codec()
+			if err != nil {
+				return err
+			}
+
+			// Will contain the initial state of the resource to edit
+			buffer := &bytes.Buffer{}
+
+			if opts.IO.OutputFormat == "yaml" {
+				buffer.WriteString(`# Please edit the resource below. Lines beginning with a '#' will be ignored,
+# and an empty file will cancel the edit.
+
+`)
+			}
+
+			if err := codec.Encode(buffer, res.Resources.Items[0].Object); err != nil {
+				return err
+			}
+
+			original := buffer.Bytes()
+			cleanup, edited, err := edit.OpenInTempFile(ctx, buffer, opts.IO.OutputFormat)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			if len(edited) == 0 {
+				cmdio.Info(cmd.OutOrStdout(), "Edit cancelled: empty file.")
+				return nil
+			}
+
+			if bytes.Equal(original, edited) {
+				cmdio.Info(cmd.OutOrStdout(), "Edit cancelled: no changes were made.")
+				return nil
+			}
+
+			tmpRes := resources.NewResources()
+			err = reader.ReadBytes(ctx, tmpRes, edited, opts.IO.OutputFormat)
+			if err != nil {
+				return err
+			}
+
+			err = pusher.Push(ctx, resources.PushRequest{
+				Resources:         tmpRes,
+				MaxConcurrency:    1,
+				StopOnError:       true,
+				OverwriteExisting: true,
+			})
+			if err != nil {
+				return err
+			}
+
+			cmdio.Success(cmd.OutOrStdout(), "Edited!")
+
+			return nil
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}

--- a/cmd/resources/editor.go
+++ b/cmd/resources/editor.go
@@ -1,0 +1,124 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+)
+
+type editor struct {
+	shellArgs  []string
+	editorName string
+}
+
+const (
+	defaultShell  = "/bin/bash"
+	defaultEditor = "vi"
+	windowsShell  = "cmd"
+	windowsEditor = "notepad"
+)
+
+func editorFromEnv() editor {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = platformize(defaultShell, windowsShell)
+	}
+
+	flag := "-c"
+	if shell == windowsShell {
+		flag = "/C"
+	}
+
+	editorName := os.Getenv("EDITOR")
+	if editorName == "" {
+		editorName = platformize(defaultEditor, windowsEditor)
+	}
+
+	return editor{
+		shellArgs:  []string{shell, flag},
+		editorName: editorName,
+	}
+}
+
+func (e editor) Open(ctx context.Context, file string) error {
+	logger := logging.FromContext(ctx).With(slog.String("component", "editor"))
+	logger.Debug("Opening file", slog.String("path", file))
+
+	absPath, err := filepath.Abs(file)
+	if err != nil {
+		return err
+	}
+
+	args := make([]string, len(e.shellArgs)+1)
+	copy(args, e.shellArgs)
+
+	args[len(e.shellArgs)] = fmt.Sprintf("%s %q", e.editorName, absPath)
+
+	logger.Debug("Starting editor", slog.String("command", strings.Join(args, " ")))
+	//nolint:gosec
+	cmd := exec.Command(args[0], args[1:]...)
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	return cmd.Run()
+}
+
+func (e editor) OpenInTempFile(ctx context.Context, buffer io.Reader, format string) (func(), []byte, error) {
+	logger := logging.FromContext(ctx).With(slog.String("component", "editor"))
+	logger.Debug("Opening buffer")
+
+	cleanup := func() {}
+
+	tmpFilePattern := "grafanactl-*-edit"
+	if format != "" {
+		tmpFilePattern += "." + format
+	}
+
+	f, err := os.CreateTemp("", tmpFilePattern)
+	if err != nil {
+		return cleanup, nil, err
+	}
+	defer f.Close()
+
+	cleanup = func() {
+		os.Remove(f.Name())
+	}
+
+	logger.Debug("Temporary file created", slog.String("path", f.Name()))
+	tmpFilePath := f.Name()
+
+	if _, err := io.Copy(f, buffer); err != nil {
+		os.Remove(tmpFilePath)
+		return cleanup, nil, err
+	}
+	// Release the file descriptor to make sure the editor can use it.
+	f.Close()
+
+	if err := e.Open(ctx, tmpFilePath); err != nil {
+		return cleanup, nil, err
+	}
+
+	contents, err := os.ReadFile(tmpFilePath)
+	if err != nil {
+		return cleanup, nil, err
+	}
+
+	return cleanup, contents, err
+}
+
+func platformize(linux string, windows string) string {
+	if runtime.GOOS == "windows" {
+		return windows
+	}
+	return linux
+}

--- a/cmd/resources/fetch.go
+++ b/cmd/resources/fetch.go
@@ -3,14 +3,16 @@ package resources
 import (
 	"context"
 
+	"github.com/grafana/grafanactl/cmd/fail"
 	"github.com/grafana/grafanactl/internal/config"
 	"github.com/grafana/grafanactl/internal/resources"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type fetchRequest struct {
-	Config      config.NamespacedRESTConfig
-	StopOnError bool
+	Config             config.NamespacedRESTConfig
+	StopOnError        bool
+	ExpectSingleTarget bool
 }
 
 type fetchResponse struct {
@@ -27,6 +29,13 @@ func fetchResources(ctx context.Context, opts fetchRequest, args []string) (*fet
 	pull, err := resources.NewPuller(ctx, opts.Config)
 	if err != nil {
 		return nil, err
+	}
+
+	if opts.ExpectSingleTarget && !sels.IsSingleTarget() {
+		return nil, fail.DetailedError{
+			Summary: "Invalid resource selector",
+			Details: "Expected a resource selector targeting a single resource. Example: dashboard/some-dashboard",
+		}
 	}
 
 	res := fetchResponse{

--- a/docs/reference/cli/grafanactl_resources.md
+++ b/docs/reference/cli/grafanactl_resources.md
@@ -27,6 +27,7 @@ TODO: more information.
 ### SEE ALSO
 
 * [grafanactl](grafanactl.md)	 - 
+* [grafanactl resources edit](grafanactl_resources_edit.md)	 - Edit resources from Grafana
 * [grafanactl resources get](grafanactl_resources_get.md)	 - Get resources from Grafana
 * [grafanactl resources list](grafanactl_resources_list.md)	 - List available Grafana API resources
 * [grafanactl resources pull](grafanactl_resources_pull.md)	 - Pull resources from Grafana

--- a/docs/reference/cli/grafanactl_resources_edit.md
+++ b/docs/reference/cli/grafanactl_resources_edit.md
@@ -1,0 +1,55 @@
+## grafanactl resources edit
+
+Edit resources from Grafana
+
+### Synopsis
+
+Edit resources from Grafana using the default editor.
+
+This command allows the edition of any resource that can be accessed by this CLI tool.
+
+It will open the default editor as configured by the EDITOR environment variable, or fall back to 'vi' for Linux or 'notepad' for Windows.
+The editor will be started in the shell set by the SHELL environment variable. If undefined, '/bin/bash' is used for Linux or 'cmd' for Windows.
+
+The edition will be cancelled if no changes are written to the file or if the file after edition is empty.
+
+
+```
+grafanactl resources edit RESOURCE_SELECTOR [flags]
+```
+
+### Examples
+
+```
+
+	# Editing a dashboard
+	grafanactl resources dashboard/foo
+
+	# Editing a dashboard in JSON
+	grafanactl resources -o json dashboard/foo
+
+	# Using an alternative editor
+	EDITOR=nvim grafanactl resources dashboard/foo
+
+```
+
+### Options
+
+```
+  -h, --help            help for edit
+  -o, --output string   Output format. One of: json, yaml (default "yaml")
+```
+
+### Options inherited from parent commands
+
+```
+      --config string    Path to the configuration file to use
+      --context string   Name of the context to use
+      --no-color         Disable color output
+  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [grafanactl resources](grafanactl_resources.md)	 - Manipulate Grafana resources
+


### PR DESCRIPTION
This PR introduces an edit command that can edit resources "in-place" using the configured default editor.

See the command's help text for more details on how it works :)