### PR TITLE
Serve folders from the remote grafana instance when they don't exist in memory

### DIFF
--- a/internal/server/handlers/dashboards-proxy.go
+++ b/internal/server/handlers/dashboards-proxy.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/http/httputil"
 	"os"
 
 	"github.com/go-chi/chi/v5"
@@ -46,7 +47,7 @@ func (c *DashboardProxy) ProxyURL(uid string) string {
 	return fmt.Sprintf("/d/%s/slug", uid)
 }
 
-func (c *DashboardProxy) Endpoints() []HTTPEndpoint {
+func (c *DashboardProxy) Endpoints(_ *httputil.ReverseProxy) []HTTPEndpoint {
 	return []HTTPEndpoint{
 		{
 			Method:  http.MethodGet,

--- a/internal/server/handlers/proxy.go
+++ b/internal/server/handlers/proxy.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"net/http/httputil"
 
 	"github.com/grafana/grafanactl/internal/resources"
 )
@@ -12,7 +13,7 @@ type ResourceHandler interface {
 	ResourceType() resources.GroupVersionKind
 
 	// Endpoints lists HTTP handlers to register on the proxy.
-	Endpoints() []HTTPEndpoint
+	Endpoints(proxy *httputil.ReverseProxy) []HTTPEndpoint
 
 	// ProxyURL returns a URL path for a resource on the proxy
 	ProxyURL(uid string) string


### PR DESCRIPTION
When dashboards defined within a folder are served via the proxy, the UI will try to load the folder (to display its title I guess).

If that folder isn't loaded in memory by grafanactl, the server should fetch it from the remote grafana instance.