### PR TITLE
Fix `resources serve` command to work with subpath

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,6 @@ linters:
   default: all
   disable:
     - cyclop
-    - depguard
     - err113
     - exhaustive
     - exhaustruct
@@ -30,6 +29,12 @@ linters:
     errcheck:
       exclude-functions:
         - fmt:.*
+    depguard:
+      rules:
+        debug_tools:
+          deny:
+            - pkg: "github.com/davecgh/go-spew"
+              desc: debug statements should be removed
 
   exclusions:
     generated: lax


### PR DESCRIPTION
This PR ensures that `grafanactl resources serve` still works even when Grafana is accessible via a subpath.