### PR TITLE
Set json as default format when working with resources

### DIFF
--- a/cmd/config/command.go
+++ b/cmd/config/command.go
@@ -140,6 +140,7 @@ type viewOpts struct {
 }
 
 func (opts *viewOpts) BindFlags(flags *pflag.FlagSet) {
+	opts.IO.DefaultFormat("yaml")
 	opts.IO.BindFlags(flags)
 
 	flags.BoolVar(&opts.Minify, "minify", opts.Minify, "Remove all information not used by current-context from the output")

--- a/cmd/io/format.go
+++ b/cmd/io/format.go
@@ -31,7 +31,7 @@ func (opts *Options) DefaultFormat(name string) {
 }
 
 func (opts *Options) BindFlags(flags *pflag.FlagSet) {
-	defaultFormat := "yaml"
+	defaultFormat := "json"
 	if opts.defaultFormat != "" {
 		defaultFormat = opts.defaultFormat
 	}

--- a/docs/reference/cli/grafanactl_resources_pull.md
+++ b/docs/reference/cli/grafanactl_resources_pull.md
@@ -58,7 +58,7 @@ grafanactl resources pull [RESOURCE_SELECTOR]... [flags]
 ```
   -d, --directory string   Directory on disk in which the resources will be written. (default "./resources")
   -h, --help               help for pull
-  -o, --output string      Output format. One of: json, yaml (default "yaml")
+  -o, --output string      Output format. One of: json, yaml (default "json")
       --stop-on-error      Stop pulling resources when an error occurs
 ```
 


### PR DESCRIPTION
To be consistent with other tools/APIs that also default to JSON.