### PR TITLE
`resource validate` command

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,6 +8,7 @@ linters:
     - exhaustruct
     - funlen
     - gocognit
+    - goconst
     - godox
     - gofumpt
     - lll
@@ -28,4 +29,4 @@ linters-settings:
 run:
   modules-download-mode: vendor
   timeout: 3m
-  go: '1.24'
+  go: "1.24"

--- a/cmd/resources/command.go
+++ b/cmd/resources/command.go
@@ -24,6 +24,7 @@ TODO: more information.
 	cmd.AddCommand(pullCmd(configOpts))
 	cmd.AddCommand(pushCmd(configOpts))
 	cmd.AddCommand(serveCmd(configOpts))
+	cmd.AddCommand(validateCmd(configOpts))
 
 	return cmd
 }

--- a/cmd/resources/validate.go
+++ b/cmd/resources/validate.go
@@ -1,0 +1,184 @@
+package resources
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	cmdconfig "github.com/grafana/grafanactl/cmd/config"
+	cmdio "github.com/grafana/grafanactl/cmd/io"
+	"github.com/grafana/grafanactl/internal/format"
+	"github.com/grafana/grafanactl/internal/resources"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type validateOpts struct {
+	IO cmdio.Options
+
+	Directories   []string
+	MaxConcurrent int
+	StopOnError   bool
+}
+
+func (opts *validateOpts) setup(flags *pflag.FlagSet) {
+	opts.IO.RegisterCustomCodec("text", &validationTableCodec{})
+	opts.IO.DefaultFormat("text")
+
+	opts.IO.BindFlags(flags)
+
+	flags.StringSliceVarP(&opts.Directories, "directory", "d", []string{defaultResourcesDir}, "Directories on disk from which to read the resources.")
+	flags.IntVar(&opts.MaxConcurrent, "max-concurrent", 10, "Maximum number of concurrent operations")
+	flags.BoolVar(&opts.StopOnError, "stop-on-error", opts.StopOnError, "Stop validating resources when an error occurs")
+}
+
+func (opts *validateOpts) Validate() error {
+	if len(opts.Directories) == 0 {
+		return errors.New("at least one directory is required")
+	}
+
+	if opts.MaxConcurrent < 1 {
+		return errors.New("max-concurrent must be greater than zero")
+	}
+
+	return nil
+}
+
+func validateCmd(configOpts *cmdconfig.Options) *cobra.Command {
+	opts := &validateOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "validate [RESOURCE_SELECTOR]...",
+		Args:  cobra.ArbitraryArgs,
+		Short: "Validate resources",
+		Long: `Validate resources.
+
+This command validates its inputs against a remote Grafana instance.
+`,
+		Example: `
+	# Validate all resources in the default directory
+	grafanactl resources validate
+
+	# Validate a single resource kind
+	grafanactl resources validate dashboards
+
+	# Validate a multiple resource kinds
+	grafanactl resources validate dashboards folders
+
+	# Displaying validation results as YAML
+	grafanactl resources validate -o yaml
+
+	# Displaying validation results as JSON
+	grafanactl resources validate -o json
+`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			codec, err := opts.IO.Codec()
+			if err != nil {
+				return err
+			}
+
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			cfg, err := configOpts.LoadRESTConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			sels, err := resources.ParseSelectors(args)
+			if err != nil {
+				return err
+			}
+
+			reader := resources.FSReader{
+				Decoders:           format.Codecs(),
+				MaxConcurrentReads: opts.MaxConcurrent,
+				StopOnError:        opts.StopOnError,
+			}
+
+			resourcesList := resources.NewResources()
+
+			if err := reader.Read(ctx, resourcesList, opts.Directories); err != nil {
+				return err
+			}
+
+			pusher, err := resources.NewPusher(ctx, cfg)
+			if err != nil {
+				return err
+			}
+
+			req := resources.PushRequest{
+				Selectors:         sels,
+				Resources:         resourcesList,
+				MaxConcurrency:    opts.MaxConcurrent,
+				StopOnError:       opts.StopOnError,
+				OverwriteExisting: true,
+				DryRun:            true,
+				NoPushFailureLog:  true,
+			}
+
+			summary, err := pusher.Push(ctx, req)
+			if err != nil {
+				return err
+			}
+
+			if summary.FailedCount == 0 && opts.IO.OutputFormat == "text" {
+				cmdio.Success(cmd.OutOrStderr(), "No errors found.")
+				return nil
+			}
+
+			if opts.IO.OutputFormat == "text" {
+				return codec.Encode(cmd.OutOrStdout(), summary)
+			}
+
+			printableSummary := struct {
+				Failures []map[string]string `json:"failures" yaml:"failures"`
+			}{
+				Failures: make([]map[string]string, 0),
+			}
+
+			for _, failure := range summary.Failures {
+				printableSummary.Failures = append(printableSummary.Failures, map[string]string{
+					"file":  failure.Resource.SourcePath(),
+					"error": failure.Error.Error(),
+				})
+			}
+
+			return codec.Encode(cmd.OutOrStdout(), printableSummary)
+		},
+	}
+
+	opts.setup(cmd.Flags())
+
+	return cmd
+}
+
+type validationTableCodec struct {
+}
+
+func (c *validationTableCodec) Format() format.Format {
+	return "text"
+}
+
+func (c *validationTableCodec) Encode(output io.Writer, input any) error {
+	//nolint:forcetypeassert
+	summary := input.(*resources.PushSummary)
+
+	tab := tabwriter.NewWriter(output, 0, 4, 2, ' ', tabwriter.TabIndent|tabwriter.DiscardEmptyColumns)
+
+	fmt.Fprintf(tab, "FILE\tERROR\n")
+	for _, failure := range summary.Failures {
+		file := failure.Resource.SourcePath()
+		fmt.Fprintf(tab, "%s\t%s\n", file, failure.Error)
+	}
+
+	return tab.Flush()
+}
+
+func (c *validationTableCodec) Decode(io.Reader, any) error {
+	return errors.New("codec does not support decoding")
+}

--- a/docs/reference/cli/grafanactl_resources.md
+++ b/docs/reference/cli/grafanactl_resources.md
@@ -32,4 +32,5 @@ TODO: more information.
 * [grafanactl resources pull](grafanactl_resources_pull.md)	 - Pull resources from Grafana
 * [grafanactl resources push](grafanactl_resources_push.md)	 - Push resources to Grafana
 * [grafanactl resources serve](grafanactl_resources_serve.md)	 - Serve Grafana resources locally
+* [grafanactl resources validate](grafanactl_resources_validate.md)	 - Validate resources
 

--- a/docs/reference/cli/grafanactl_resources_validate.md
+++ b/docs/reference/cli/grafanactl_resources_validate.md
@@ -1,0 +1,59 @@
+## grafanactl resources validate
+
+Validate resources
+
+### Synopsis
+
+Validate resources.
+
+This command validates its inputs against a remote Grafana instance.
+
+
+```
+grafanactl resources validate [RESOURCE_SELECTOR]... [flags]
+```
+
+### Examples
+
+```
+
+	# Validate all resources in the default directory
+	grafanactl resources validate
+
+	# Validate a single resource kind
+	grafanactl resources validate dashboards
+
+	# Validate a multiple resource kinds
+	grafanactl resources validate dashboards folders
+
+	# Displaying validation results as YAML
+	grafanactl resources validate -o yaml
+
+	# Displaying validation results as JSON
+	grafanactl resources validate -o json
+
+```
+
+### Options
+
+```
+  -d, --directory strings    Directories on disk from which to read the resources. (default [./resources])
+  -h, --help                 help for validate
+      --max-concurrent int   Maximum number of concurrent operations (default 10)
+  -o, --output string        Output format. One of: json, text, yaml (default "text")
+      --stop-on-error        Stop validating resources when an error occurs
+```
+
+### Options inherited from parent commands
+
+```
+      --config string    Path to the configuration file to use
+      --context string   Name of the context to use
+      --no-color         Disable color output
+  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [grafanactl resources](grafanactl_resources.md)	 - Manipulate Grafana resources
+


### PR DESCRIPTION
This command could be considered "syntactic sugar" on top of the push + `--dry-run` command.
But like we did for the `resources get` vs `resources pull` command, having a dedicated command to validate resources allow us some validation-specific option, especially when it comes to reporting validation failures.

Note: I open this PR purely as a suggestion, if we don't like it (or feel that we don't need it), I'll just close it :)