### PR TITLE
Add a "config list-contexts" command

### DIFF
--- a/cmd/config/command.go
+++ b/cmd/config/command.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/caarlos0/env/v11"
 	"github.com/grafana/grafanactl/cmd/fail"
@@ -128,6 +129,7 @@ The configuration file to load is chosen as follows:
 	cmd.AddCommand(unsetCmd(configOpts))
 	cmd.AddCommand(useContextCmd(configOpts))
 	cmd.AddCommand(viewCmd(configOpts))
+	cmd.AddCommand(listContextsCmd(configOpts))
 
 	return cmd
 }
@@ -215,6 +217,43 @@ func currentContextCmd(configOpts *Options) *cobra.Command {
 			cmd.Println(cfg.CurrentContext)
 
 			return nil
+		},
+	}
+
+	return cmd
+}
+
+func listContextsCmd(configOpts *Options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list-contexts",
+		Args:    cobra.NoArgs,
+		Short:   "List the contexts defined in the configuration",
+		Long:    "List the contexts defined in the configuration.",
+		Example: "\n\tgrafanactl config list-contexts",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := configOpts.loadConfigTolerant(cmd.Context())
+			if err != nil {
+				return err
+			}
+
+			tab := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', tabwriter.TabIndent|tabwriter.DiscardEmptyColumns)
+
+			fmt.Fprintf(tab, "CURRENT\tNAME\tGRAFANA SERVER\n")
+			for _, context := range cfg.Contexts {
+				server := " "
+				if context.Grafana != nil {
+					server = context.Grafana.Server
+				}
+
+				current := " "
+				if cfg.CurrentContext == context.Name {
+					current = "*"
+				}
+
+				fmt.Fprintf(tab, "%s\t%s\t%s\n", current, context.Name, server)
+			}
+
+			return tab.Flush()
 		},
 	}
 

--- a/docs/reference/cli/grafanactl_config.md
+++ b/docs/reference/cli/grafanactl_config.md
@@ -37,6 +37,7 @@ The configuration file to load is chosen as follows:
 * [grafanactl](grafanactl.md)	 - 
 * [grafanactl config check](grafanactl_config_check.md)	 - Check the current configuration for issues
 * [grafanactl config current-context](grafanactl_config_current-context.md)	 - Display the current context name
+* [grafanactl config list-contexts](grafanactl_config_list-contexts.md)	 - List the contexts defined in the configuration
 * [grafanactl config set](grafanactl_config_set.md)	 - Set an single value in a configuration file
 * [grafanactl config unset](grafanactl_config_unset.md)	 - Unset an single value in a configuration file
 * [grafanactl config use-context](grafanactl_config_use-context.md)	 - Set the current context

--- a/docs/reference/cli/grafanactl_config_list-contexts.md
+++ b/docs/reference/cli/grafanactl_config_list-contexts.md
@@ -1,0 +1,38 @@
+## grafanactl config list-contexts
+
+List the contexts defined in the configuration
+
+### Synopsis
+
+List the contexts defined in the configuration.
+
+```
+grafanactl config list-contexts [flags]
+```
+
+### Examples
+
+```
+
+	grafanactl config list-contexts
+```
+
+### Options
+
+```
+  -h, --help   help for list-contexts
+```
+
+### Options inherited from parent commands
+
+```
+      --config string    Path to the configuration file to use
+      --context string   Name of the context to use
+      --no-color         Disable color output
+  -v, --verbose count    Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [grafanactl config](grafanactl_config.md)	 - View or manipulate configuration settings
+


### PR DESCRIPTION
This command can be quite useful to see available contexts and check which one is active, without having to go through the entire configuration YAML.