### PR TITLE
Use `-buildvcs=false` when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ tests: check-binaries ## Runs the tests.
 
 .PHONY: build
 build: check-binaries ## Builds the binary into the `./bin/grafanactl`.
-	$(RUN_DEVBOX) go build -o bin/grafanactl ./cmd
+	$(RUN_DEVBOX) go build -buildvcs=false -o bin/grafanactl ./cmd
 
 .PHONY: install
 install: build ## Installs the binary into `$GOPATH/bin`.


### PR DESCRIPTION
allows me to run `make build` on my system.

If this is not a good idea -- please close and I can run it manually.

Without it, I get:
```
$ make build
devbox run go build -o bin/grafanactl ./cmd
Info: Running script "go" on /Users/ryan/workspace/grafana/grafanactl
Entering Python venv
Installing dependencies...
make[1]: Entering directory '/Users/ryan/workspace/grafana/grafanactl'
go mod vendor
pip install -qq -r requirements.txt
make[1]: Leaving directory '/Users/ryan/workspace/grafana/grafanactl'
error obtaining VCS status: exit status 1
	Use -buildvcs=false to disable VCS stamping.
Error: error running script "go" in Devbox: exit status 1

make: *** [build] Error 1
```