### PR TITLE
Add a small introduction in the documentation's homepage

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,7 @@
+{
+  "default": true,
+  "single-title": {
+    "front_matter_title": ""
+  },
+  "line-length": false
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,13 @@
 title: Home
 ---
 
-# grafanactl
+# Grafana CLI
 
-TBD.
+Grafana CLI (_grafanactl_) is a command-line tool designed to simplify interaction with Grafana instances.
+
+It enables users to authenticate, manage multiple environments, and perform administrative tasks through Grafana's REST API — all from the terminal.
+
+Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, Grafana CLI provides a flexible and scriptable way to manage your Grafana setup efficiently.
 
 ## Maturity
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: grafanactl
-site_author: 'Grafana Labs'
+site_name: Grafana CLI
+site_author: "Grafana Labs"
 
 repo_name: "grafana/grafanactl"
 repo_url: "https://github.com/grafana/grafanactl"


### PR DESCRIPTION
To briefly introduce the tool and have the homepage feels less empty.