### PR TITLE
Add version information when building locally

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,6 +12,8 @@ builds:
 
     ldflags:
       - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
 
     env:
       - CGO_ENABLED=0

--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,18 @@ lint: check-binaries ## Lints the code base.
 tests: check-binaries ## Runs the tests.
 	$(RUN_DEVBOX) go test -v ./...
 
+GIT_REVISION  ?= $(shell git rev-parse --short HEAD)
+GIT_VERSION   ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "")
+BUILD_DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+VERSION_FLAGS := -X main.version=${GIT_VERSION} -X main.commit=${GIT_REVISION} -X main.date=${BUILD_DATE}
+
 .PHONY: build
 build: check-binaries ## Builds the binary into the `./bin/grafanactl`.
-	$(RUN_DEVBOX) go build -buildvcs=false -o bin/grafanactl ./cmd/grafanactl
+	$(RUN_DEVBOX) go build \
+		-buildvcs=false \
+		-ldflags="${VERSION_FLAGS}" \
+		-o bin/grafanactl \
+		./cmd/grafanactl
 
 .PHONY: install
 install: build ## Installs the binary into `$GOPATH/bin`.

--- a/cmd/grafanactl/main.go
+++ b/cmd/grafanactl/main.go
@@ -8,10 +8,17 @@ import (
 	"github.com/grafana/grafanactl/cmd/grafanactl/root"
 )
 
-var version = "SNAPSHOT"
+// Version variables which are set at build time.
+var (
+	version string
+	//nolint:gochecknoglobals
+	commit string
+	//nolint:gochecknoglobals
+	date string
+)
 
 func main() {
-	handleError(root.Command(version).Execute())
+	handleError(root.Command(formatVersion()).Execute())
 }
 
 func handleError(err error) {
@@ -29,4 +36,12 @@ func handleError(err error) {
 	}
 
 	os.Exit(exitCode)
+}
+
+func formatVersion() string {
+	if version == "" {
+		version = "SNAPSHOT"
+	}
+
+	return fmt.Sprintf("%s built from %s on %s", version, commit, date)
 }


### PR DESCRIPTION
### What

This commit updates local build pipeline to populate version information and expands the version data to cover commit and build date.

### Why

To make it easier to debug locally-built versions.