### PR TITLE
Fix CI security scan results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
 env:
   DEVBOX_VERSION: 0.14.0
 
+permissions:
+  contents: read
+
 jobs:
   linters:
     name: Linters

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
@@ -28,7 +31,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Run golangci-lint
@@ -39,7 +42,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #4.2.3
@@ -54,7 +60,7 @@ jobs:
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Tests
@@ -65,12 +71,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
-          enable-cache: 'true'
+          enable-cache: "true"
           devbox-version: ${{ env.DEVBOX_VERSION }}
 
       - name: Check for drift in the generated documentation references

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -2,11 +2,6 @@ name: Publish documentation
 on:
   workflow_dispatch: ~
 
-permissions:
-  contents: read
-  pages: write      # to deploy to Pages
-  id-token: write   # to verify the deployment originates from an appropriate source
-
 env:
   DEVBOX_VERSION: 0.14.0
 
@@ -19,6 +14,8 @@ concurrency:
 jobs:
   build_docs:
     name: Build
+    permissions:
+      pages: write
     runs-on: ubuntu-latest
 
     # Deploy to the github-pages environment
@@ -27,7 +24,10 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
@@ -46,6 +46,9 @@ jobs:
 
   publish_documentation:
     needs: build_docs
+    permissions:
+      pages: write
+      id-token: write
 
     name: Publish
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
   push:
     tags: ["v*"]
 
-permissions:
-  contents: write # to push new branches
-  pages: write # to deploy to Pages
-  id-token: write # to verify the deployment originates from an appropriate source
-
 env:
   DEVBOX_VERSION: 0.14.0
 
@@ -22,12 +17,16 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push new branches
+      id-token: write # to verify the deployment originates from an appropriate source
 
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
@@ -62,6 +61,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
@@ -80,7 +81,9 @@ jobs:
 
   publish_documentation:
     needs: [build_docs, release]
-
+    permissions:
+      pages: write
+      id-token: write
     name: Publish documentation
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,9 @@ concurrency:
   group: "releases"
   cancel-in-progress: false
 
+permissions:
+  contents: read # to push new branches
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
I ran `zimzor` against the repo and wanted to address the high vulnernabilities that could easily be exploited. This addresses some of the more likely scenarios and updated permissions to be scoped to specific steps. With CI disabled, these are difficult to guarantee success, but gets us closer to a better state and should be relatively easy to fix in the future.