### PR TITLE
Remove server-side fields when pulling resources

### DIFF
--- a/cmd/grafanactl/resources/delete.go
+++ b/cmd/grafanactl/resources/delete.go
@@ -99,7 +99,7 @@ func deleteCmd(configOpts *cmdconfig.Options) *cobra.Command {
 				}
 			}
 
-			res := resources.NewResources()
+			var res resources.Resources
 
 			// Load resources by selectors only
 			if len(opts.Directories) == 0 {
@@ -111,13 +111,11 @@ func deleteCmd(configOpts *cmdconfig.Options) *cobra.Command {
 					return err
 				}
 
-				res, err = resources.NewResourcesFromUnstructured(fetchRes.Resources)
-				if err != nil {
-					return err
-				}
+				res = fetchRes.Resources
 			} else {
 				// Load resources from the filesystem
-				if err := loadResourcesFromDirectories(ctx, cfg, res, opts, sels); err != nil {
+				res = *resources.NewResources()
+				if err := loadResourcesFromDirectories(ctx, cfg, &res, opts, sels); err != nil {
 					return err
 				}
 			}
@@ -133,7 +131,7 @@ func deleteCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			}
 
 			req := remote.DeleteRequest{
-				Resources:      res,
+				Resources:      &res,
 				MaxConcurrency: opts.MaxConcurrent,
 				StopOnError:    opts.StopOnError,
 				DryRun:         opts.DryRun,

--- a/cmd/grafanactl/resources/fetch.go
+++ b/cmd/grafanactl/resources/fetch.go
@@ -8,7 +8,6 @@ import (
 	"github.com/grafana/grafanactl/internal/resources"
 	"github.com/grafana/grafanactl/internal/resources/discovery"
 	"github.com/grafana/grafanactl/internal/resources/remote"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type fetchRequest struct {
@@ -18,7 +17,7 @@ type fetchRequest struct {
 }
 
 type fetchResponse struct {
-	Resources      unstructured.UnstructuredList
+	Resources      resources.Resources
 	IsSingleTarget bool
 }
 

--- a/cmd/grafanactl/resources/list.go
+++ b/cmd/grafanactl/resources/list.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"slices"
-	"strings"
 	"text/tabwriter"
 
 	cmdconfig "github.com/grafana/grafanactl/cmd/grafanactl/config"
@@ -69,22 +67,7 @@ func listCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			// TODO: refactor this to return a k8s object list,
 			// e.g. APIResourceList, or unstructured.UnstructuredList.
 			// That way we can use the same code for rendering as for `resources get`.
-			res := reg.SupportedResources()
-
-			slices.SortStableFunc(res, func(a, b resources.Descriptor) int {
-				res := strings.Compare(a.GroupVersion.Group, b.GroupVersion.Group)
-				if res != 0 {
-					return res
-				}
-
-				res = strings.Compare(a.GroupVersion.Version, b.GroupVersion.Version)
-				if res != 0 {
-					return res
-				}
-
-				return strings.Compare(a.Kind, b.Kind)
-			})
-
+			res := reg.SupportedResources().Sorted()
 			return codec.Encode(cmd.OutOrStdout(), res)
 		},
 	}

--- a/cmd/grafanactl/resources/push.go
+++ b/cmd/grafanactl/resources/push.go
@@ -15,18 +15,16 @@ import (
 )
 
 type pushOpts struct {
-	Directories       []string
-	MaxConcurrent     int
-	StopOnError       bool
-	OverwriteExisting bool
-	DryRun            bool
+	Directories   []string
+	MaxConcurrent int
+	StopOnError   bool
+	DryRun        bool
 }
 
 func (opts *pushOpts) setup(flags *pflag.FlagSet) {
 	flags.StringSliceVarP(&opts.Directories, "directory", "d", []string{defaultResourcesDir}, "Directories on disk from which to read the resources to push")
 	flags.IntVar(&opts.MaxConcurrent, "max-concurrent", 10, "Maximum number of concurrent operations")
 	flags.BoolVar(&opts.StopOnError, "stop-on-error", opts.StopOnError, "Stop pushing resources when an error occurs")
-	flags.BoolVar(&opts.OverwriteExisting, "overwrite", opts.OverwriteExisting, "Overwrite existing resources")
 	flags.BoolVar(&opts.DryRun, "dry-run", opts.DryRun, "If set, the push operation will be simulated, without actually creating or updating any resources")
 }
 
@@ -133,11 +131,10 @@ func pushCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			}
 
 			req := remote.PushRequest{
-				Resources:         resourcesList,
-				MaxConcurrency:    opts.MaxConcurrent,
-				StopOnError:       opts.StopOnError,
-				OverwriteExisting: opts.OverwriteExisting,
-				DryRun:            opts.DryRun,
+				Resources:      resourcesList,
+				MaxConcurrency: opts.MaxConcurrent,
+				StopOnError:    opts.StopOnError,
+				DryRun:         opts.DryRun,
 			}
 
 			summary, err := pusher.Push(ctx, req)

--- a/cmd/grafanactl/resources/validate.go
+++ b/cmd/grafanactl/resources/validate.go
@@ -125,12 +125,11 @@ This command validates its inputs against a remote Grafana instance.
 			}
 
 			req := remote.PushRequest{
-				Resources:         resourcesList,
-				MaxConcurrency:    opts.MaxConcurrent,
-				StopOnError:       opts.StopOnError,
-				OverwriteExisting: true,
-				DryRun:            true,
-				NoPushFailureLog:  true,
+				Resources:        resourcesList,
+				MaxConcurrency:   opts.MaxConcurrent,
+				StopOnError:      opts.StopOnError,
+				DryRun:           true,
+				NoPushFailureLog: true,
 			}
 
 			summary, err := pusher.Push(ctx, req)

--- a/docs/reference/cli/grafanactl_resources_push.md
+++ b/docs/reference/cli/grafanactl_resources_push.md
@@ -60,7 +60,6 @@ grafanactl resources push [RESOURCE_SELECTOR]... [flags]
       --dry-run              If set, the push operation will be simulated, without actually creating or updating any resources
   -h, --help                 help for push
       --max-concurrent int   Maximum number of concurrent operations (default 10)
-      --overwrite            Overwrite existing resources
       --stop-on-error        Stop pushing resources when an error occurs
 ```
 

--- a/internal/resources/descriptor.go
+++ b/internal/resources/descriptor.go
@@ -2,12 +2,33 @@ package resources
 
 import (
 	"fmt"
+	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Descriptors is a list of descriptors.
 type Descriptors []Descriptor
+
+// Sorted sorts the descriptors by group, version, kind, and name.
+func (d Descriptors) Sorted() Descriptors {
+	slices.SortStableFunc(d, func(a, b Descriptor) int {
+		res := strings.Compare(a.GroupVersion.Group, b.GroupVersion.Group)
+		if res != 0 {
+			return res
+		}
+
+		res = strings.Compare(a.GroupVersion.Version, b.GroupVersion.Version)
+		if res != 0 {
+			return res
+		}
+
+		return strings.Compare(a.Kind, b.Kind)
+	})
+
+	return d
+}
 
 // Descriptor describes a resource.
 type Descriptor struct {

--- a/internal/resources/filter_test.go
+++ b/internal/resources/filter_test.go
@@ -43,7 +43,7 @@ func TestFilter_Matches(t *testing.T) {
 	tests := []struct {
 		name     string
 		filter   resources.Filter
-		resource resources.Resource
+		resource *resources.Resource
 		want     bool
 	}{
 		{
@@ -108,7 +108,7 @@ func TestFilter_Matches(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := test.filter.Matches(test.resource)
+			got := test.filter.Matches(*test.resource)
 			if got != test.want {
 				t.Errorf("got %v, want %v", got, test.want)
 			}

--- a/internal/resources/local/reader.go
+++ b/internal/resources/local/reader.go
@@ -75,7 +75,7 @@ func (reader *FSReader) ReadBytes(ctx context.Context, dst *resources.Resources,
 		return err
 	}
 
-	dst.Add(&r)
+	dst.Add(r)
 
 	return nil
 }

--- a/internal/resources/process/serverfields.go
+++ b/internal/resources/process/serverfields.go
@@ -1,0 +1,59 @@
+package process
+
+import (
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafanactl/internal/resources"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ServerFieldsStripper is a processor that strips server-side fields from resources.
+type ServerFieldsStripper struct{}
+
+// Process strips server-side fields from resources.
+func (m *ServerFieldsStripper) Process(src *resources.Resources) (*resources.Resources, error) {
+	list := unstructured.UnstructuredList{
+		Items: make([]unstructured.Unstructured, 0, src.Len()),
+	}
+
+	if err := src.ForEach(func(r *resources.Resource) error {
+		spec, err := r.Raw.GetSpec()
+		if err != nil {
+			return err
+		}
+
+		// Remove annotations set by the server.
+		annotations := r.Raw.GetAnnotations()
+		delete(annotations, utils.AnnoKeyCreatedBy)
+		delete(annotations, utils.AnnoKeyUpdatedBy)
+		delete(annotations, utils.AnnoKeyUpdatedTimestamp)
+
+		// Remove labels set by the server.
+		labels := r.Raw.GetLabels()
+		delete(labels, utils.LabelKeyDeprecatedInternalID)
+
+		list.Items = append(list.Items, unstructured.Unstructured{
+			Object: map[string]any{
+				"apiVersion": r.APIVersion(),
+				"kind":       r.Kind(),
+				"metadata": map[string]any{
+					"name":        r.Name(),
+					"namespace":   r.Namespace(),
+					"annotations": annotations,
+					"labels":      labels,
+				},
+				"spec": spec,
+			},
+		})
+
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return resources.NewResourcesFromUnstructured(list)
+}
+
+// Name returns the name of the processor.
+func (m *ServerFieldsStripper) Name() string {
+	return "strip-server-fields"
+}

--- a/internal/resources/process/serverfields_test.go
+++ b/internal/resources/process/serverfields_test.go
@@ -1,0 +1,90 @@
+package process_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafanactl/internal/resources"
+	"github.com/grafana/grafanactl/internal/resources/process"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerFieldsStripper_Process(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *resources.Resources
+		want    *resources.Resources
+		wantErr bool
+	}{
+		{
+			name:    "no resources",
+			input:   resources.NewResources(),
+			want:    resources.NewResources(),
+			wantErr: false,
+		},
+		{
+			name: "one resource",
+			input: resources.NewResources(
+				resources.MustFromObject(map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":              "example",
+						"namespace":         "default",
+						"uid":               "test",
+						"generation":        1,
+						"resourceVersion":   "1",
+						"creationTimestamp": "2021-01-01T00:00:00Z",
+						"annotations": map[string]any{
+							utils.AnnoKeyCreatedBy:        "test",
+							utils.AnnoKeyUpdatedBy:        "test",
+							utils.AnnoKeyUpdatedTimestamp: "2021-01-01T00:00:00Z",
+							"test-annotation":             "test",
+						},
+						"labels": map[string]any{
+							utils.LabelKeyDeprecatedInternalID: "test",
+							"test-label":                       "test",
+						},
+					},
+					"spec": map[string]any{
+						"foo": "bar",
+					},
+				}),
+			),
+			want: resources.NewResources(
+				resources.MustFromObject(map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "default",
+						"annotations": map[string]string{
+							"test-annotation": "test",
+						},
+						"labels": map[string]string{
+							"test-label": "test",
+						},
+					},
+					"spec": map[string]any{
+						"foo": "bar",
+					},
+				}),
+			),
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			proc := &process.ServerFieldsStripper{}
+			actual, err := proc.Process(test.input)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, actual.ToUnstructuredList(), test.want.ToUnstructuredList())
+		})
+	}
+}


### PR DESCRIPTION
### What

This commit changes the logic of pulling resources to strip them from server-side fields like resourceVersion, generation and so on, as well as some well-known server-side annotations & labels.

It also removes the "overwrite" flag used for pushing since that is the new default behaviour.

### Why

We are removing the ability to pull resources in their "backup" format for now since it prevents the use-cases of e.g. migrating resources from one instance to another and is overall a buggy experience.