### PR TITLE
fix: Improve CI Security

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
 env:
   DEVBOX_VERSION: 0.14.0
 
+permissions:
+  contents: read
+
 jobs:
   linters:
     name: Linters
@@ -14,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
@@ -40,6 +45,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Restore go vendors
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #4.2.3
@@ -66,6 +73,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,8 +4,6 @@ on:
 
 permissions:
   contents: read
-  pages: write      # to deploy to Pages
-  id-token: write   # to verify the deployment originates from an appropriate source
 
 env:
   DEVBOX_VERSION: 0.14.0
@@ -28,7 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
-
+        with:
+          persist-credentials: false
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
         with:
@@ -45,6 +44,10 @@ jobs:
           path: ./build/documentation
 
   publish_documentation:
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
     needs: build_docs
 
     name: Publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write # to push new branches
-  pages: write # to deploy to Pages
-  id-token: write # to verify the deployment originates from an appropriate source
+  contents: read
 
 env:
   DEVBOX_VERSION: 0.14.0
@@ -20,6 +18,8 @@ concurrency:
 
 jobs:
   release:
+    permissions:
+      contents: write # to push new branches
     name: Release
     runs-on: ubuntu-latest
 
@@ -28,9 +28,10 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Restore go vendors
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 #v4.2.3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # zizmor: ignore[cache-poisoning] this is actually fine #v4.2.3 
         with:
           path: |
             ~/go/pkg/mod
@@ -62,6 +63,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Install devbox
         uses: jetify-com/devbox-install-action@734088efddca47cf44ff8a09289c6d0e51b73218 #v0.12.0
@@ -79,6 +82,10 @@ jobs:
           path: ./build/documentation
 
   publish_documentation:
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
     needs: [build_docs, release]
 
     name: Publish documentation


### PR DESCRIPTION
In response to:
https://grafana.com/blog/2025/04/27/grafana-security-update-no-customer-impact-from-github-workflow-vulnerability/

These enhancements will improve CI security based on findings from [zizmor](https://woodruffw.github.io/zizmor/).

Fixes:
- [x] Remove credential persistence from checkout action
- [x] Replace workflow permissions with job-specific ones
