### PR TITLE
Replace pull / push / validate directories with paths

### DIFF
--- a/cmd/grafanactl/fail/convert.go
+++ b/cmd/grafanactl/fail/convert.go
@@ -163,6 +163,18 @@ func convertFSErrors(err error) (*DetailedError, bool) {
 		}, true
 	}
 
+	if errors.Is(err, os.ErrInvalid) && errors.As(err, &pathErr) {
+		return &DetailedError{
+			Summary: "Invalid path",
+			Details: fmt.Sprintf("path '%s' is not valid", pathErr.Path),
+			Parent:  err,
+			Suggestions: []string{
+				"Make sure that you are passing in a valid path",
+				"If you are pulling resources make sure that the path is a directory",
+			},
+		}, true
+	}
+
 	if errors.Is(err, os.ErrPermission) && errors.As(err, &pathErr) {
 		return &DetailedError{
 			Summary: "Permission denied",

--- a/cmd/grafanactl/resources/delete.go
+++ b/cmd/grafanactl/resources/delete.go
@@ -22,7 +22,7 @@ type deleteOpts struct {
 	Force         bool
 	MaxConcurrent int
 	DryRun        bool
-	Directories   []string
+	Path          []string
 }
 
 func (opts *deleteOpts) setup(flags *pflag.FlagSet) {
@@ -30,7 +30,7 @@ func (opts *deleteOpts) setup(flags *pflag.FlagSet) {
 	flags.IntVar(&opts.MaxConcurrent, "max-concurrent", 10, "Maximum number of concurrent operations")
 	flags.BoolVar(&opts.Force, "force", opts.Force, "Delete all resources of the specified resource types")
 	flags.BoolVar(&opts.DryRun, "dry-run", opts.DryRun, "If set, the delete operation will be simulated")
-	flags.StringSliceVarP(&opts.Directories, "directory", "d", nil, "Directories on disk containing the resources to delete")
+	flags.StringSliceVarP(&opts.Path, "path", "p", nil, "Path on disk containing the resources to delete")
 }
 
 func (opts *deleteOpts) Validate(args []string) error {
@@ -38,8 +38,8 @@ func (opts *deleteOpts) Validate(args []string) error {
 		return errors.New("max-concurrent must be greater than zero")
 	}
 
-	if len(args) == 0 && len(opts.Directories) == 0 {
-		return errors.New("either --directory or resource selectors need to be specified")
+	if len(args) == 0 && len(opts.Path) == 0 {
+		return errors.New("either --path or resource selectors need to be specified")
 	}
 
 	return nil
@@ -67,10 +67,10 @@ func deleteCmd(configOpts *cmdconfig.Options) *cobra.Command {
 	grafanactl resources delete dashboards --force
 
 	# Delete every resource defined in the given directory
-	grafanactl resources delete -d ./unwanted-resources/
+	grafanactl resources delete -p ./unwanted-resources/
 
 	# Delete every dashboard defined in the given directory
-	grafanactl resources delete -d ./unwanted-resources/ dashboard
+	grafanactl resources delete -p ./unwanted-resources/ dashboard
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -102,7 +102,7 @@ func deleteCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			var res resources.Resources
 
 			// Load resources by selectors only
-			if len(opts.Directories) == 0 {
+			if len(opts.Path) == 0 {
 				fetchRes, err := fetchResources(ctx, fetchRequest{
 					Config:      cfg,
 					StopOnError: opts.StopOnError,
@@ -179,5 +179,5 @@ func loadResourcesFromDirectories(ctx context.Context, cfg config.NamespacedREST
 		return err
 	}
 
-	return reader.Read(ctx, res, filters, opts.Directories)
+	return reader.Read(ctx, res, filters, opts.Path)
 }

--- a/cmd/grafanactl/resources/pull.go
+++ b/cmd/grafanactl/resources/pull.go
@@ -12,13 +12,13 @@ import (
 )
 
 const (
-	defaultResourcesDir = "./resources"
+	defaultResourcesPath = "./resources"
 )
 
 type pullOpts struct {
 	IO          cmdio.Options
 	StopOnError bool
-	Directory   string
+	Path        string
 }
 
 func (opts *pullOpts) setup(flags *pflag.FlagSet) {
@@ -26,7 +26,7 @@ func (opts *pullOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 
 	flags.BoolVar(&opts.StopOnError, "stop-on-error", opts.StopOnError, "Stop pulling resources when an error occurs")
-	flags.StringVarP(&opts.Directory, "directory", "d", defaultResourcesDir, "Directory on disk in which the resources will be written.")
+	flags.StringVarP(&opts.Path, "path", "p", defaultResourcesPath, "Path on disk in which the resources will be written.")
 }
 
 func (opts *pullOpts) Validate() error {
@@ -34,8 +34,8 @@ func (opts *pullOpts) Validate() error {
 		return err
 	}
 
-	if opts.Directory == "" {
-		return errors.New("--directory is required")
+	if opts.Path == "" {
+		return errors.New("--path is required")
 	}
 
 	return nil
@@ -113,7 +113,7 @@ func pullCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			}
 
 			writer := local.FSWriter{
-				Directory:   opts.Directory,
+				Path:        opts.Path,
 				Namer:       local.GroupResourcesByKind(opts.IO.OutputFormat),
 				Encoder:     codec,
 				StopOnError: opts.StopOnError,

--- a/cmd/grafanactl/resources/push.go
+++ b/cmd/grafanactl/resources/push.go
@@ -15,22 +15,22 @@ import (
 )
 
 type pushOpts struct {
-	Directories   []string
+	Paths         []string
 	MaxConcurrent int
 	StopOnError   bool
 	DryRun        bool
 }
 
 func (opts *pushOpts) setup(flags *pflag.FlagSet) {
-	flags.StringSliceVarP(&opts.Directories, "directory", "d", []string{defaultResourcesDir}, "Directories on disk from which to read the resources to push")
+	flags.StringSliceVarP(&opts.Paths, "path", "p", []string{defaultResourcesPath}, "Paths on disk from which to read the resources to push")
 	flags.IntVar(&opts.MaxConcurrent, "max-concurrent", 10, "Maximum number of concurrent operations")
 	flags.BoolVar(&opts.StopOnError, "stop-on-error", opts.StopOnError, "Stop pushing resources when an error occurs")
 	flags.BoolVar(&opts.DryRun, "dry-run", opts.DryRun, "If set, the push operation will be simulated, without actually creating or updating any resources")
 }
 
 func (opts *pushOpts) Validate() error {
-	if len(opts.Directories) == 0 {
-		return errors.New("at least one directory is required")
+	if len(opts.Paths) == 0 {
+		return errors.New("at least one path is required")
 	}
 
 	if opts.MaxConcurrent < 1 {
@@ -121,7 +121,7 @@ func pushCmd(configOpts *cmdconfig.Options) *cobra.Command {
 
 			resourcesList := resources.NewResources()
 
-			if err := reader.Read(ctx, resourcesList, filters, opts.Directories); err != nil {
+			if err := reader.Read(ctx, resourcesList, filters, opts.Paths); err != nil {
 				return err
 			}
 

--- a/cmd/grafanactl/resources/validate.go
+++ b/cmd/grafanactl/resources/validate.go
@@ -20,7 +20,7 @@ import (
 type validateOpts struct {
 	IO cmdio.Options
 
-	Directories   []string
+	Paths         []string
 	MaxConcurrent int
 	StopOnError   bool
 }
@@ -31,14 +31,14 @@ func (opts *validateOpts) setup(flags *pflag.FlagSet) {
 
 	opts.IO.BindFlags(flags)
 
-	flags.StringSliceVarP(&opts.Directories, "directory", "d", []string{defaultResourcesDir}, "Directories on disk from which to read the resources.")
+	flags.StringSliceVarP(&opts.Paths, "path", "p", []string{defaultResourcesPath}, "Paths on disk from which to read the resources.")
 	flags.IntVar(&opts.MaxConcurrent, "max-concurrent", 10, "Maximum number of concurrent operations")
 	flags.BoolVar(&opts.StopOnError, "stop-on-error", opts.StopOnError, "Stop validating resources when an error occurs")
 }
 
 func (opts *validateOpts) Validate() error {
-	if len(opts.Directories) == 0 {
-		return errors.New("at least one directory is required")
+	if len(opts.Paths) == 0 {
+		return errors.New("at least one path is required")
 	}
 
 	if opts.MaxConcurrent < 1 {
@@ -115,7 +115,7 @@ This command validates its inputs against a remote Grafana instance.
 
 			resourcesList := resources.NewResources()
 
-			if err := reader.Read(ctx, resourcesList, filters, opts.Directories); err != nil {
+			if err := reader.Read(ctx, resourcesList, filters, opts.Paths); err != nil {
 				return err
 			}
 

--- a/docs/guides/dashboards-as-code.md
+++ b/docs/guides/dashboards-as-code.md
@@ -1,0 +1,21 @@
+---
+title: Dashboards as code
+---
+
+With this workflow, you can define and manage dashboards as code, saving them to a version control system like Git. This is useful for teams that want to maintain a history of changes, collaborate on dashboard design, and ensure consistency across environments.
+
+1. Use a dashboard generation script (for example, with the [Foundation SDK](https://github.com/grafana/grafana-foundation-sdk)). You can find an example implementation in the Grafana as code [hands-on lab repository](https://github.com/grafana/dashboards-as-code-workshop/tree/main/part-one-golang).
+1. Serve and preview the output of the dashboard generator locally:
+   ```shell
+   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
+   grafanactl resources serve --script 'go run scripts/generate-dashboard.go' --watch './scripts'
+   ```
+1. When the output looks correct, generate dashboard manifest files:
+   ```shell
+   go run scripts/generate-dashboard.go --generate-resource-manifests --output './resources'
+   ```
+1. Push the generated resources to your Grafana instance:
+   ```shell
+   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
+   grafanactl resources push -d ./resources/
+   ```

--- a/docs/guides/manage-resources.md
+++ b/docs/guides/manage-resources.md
@@ -11,32 +11,40 @@ In this example scenario, we will use `dev` for the development environment and 
 
 1. Make changes to dashboards and other resources using the Grafana UI in your **development instance**.
 1. Pull those resources from the development environment to your local machine:
+
    ```shell
    grafanactl resources pull --context dev # Add `-o yaml` export resources as YAML 
    ```
+
 1. Push the resources to production:
+
    ```shell
    grafanactl resources push --context prod
    ```
 
 !!! note
     Resources are pulled and pushed from the `./resources` directory by default.
-    This directory can be configured with the `--directory`/`-d` flags.
+    This path can be configured with the `--path`/`-p` flags.
 
 ## Backup and restore resources
 
 This workflow helps you back up all Grafana resources from one instance and later restore them. This can be useful to replicate a configuration or perform disaster recovery.
 
 1. Ensure the current context points to the Grafana instance to backup/restore:
+
    ```shell
    grafanactl config use-context YOUR_CONTEXT  # for example "prod"
    ```
+
 1. Pull all resources from your target environment:
+
    ```shell
-   grafanactl resources pull -d ./backup-prod # Add `-o yaml` export resources as YAML
+   grafanactl resources pull --path ./backup-prod # Add `-o yaml` to export resources as YAML
    ```
+
 1. Save the exported resources to version control or cloud storage.
 1. Push the resources to restore them:
+
    ```shell
-   grafanactl resources push -d ./backup-prod
+   grafanactl resources push --path ./backup-prod
    ```

--- a/docs/reference/cli/grafanactl_resources_delete.md
+++ b/docs/reference/cli/grafanactl_resources_delete.md
@@ -27,21 +27,21 @@ grafanactl resources delete [RESOURCE_SELECTOR]... [flags]
 	grafanactl resources delete dashboards --force
 
 	# Delete every resource defined in the given directory
-	grafanactl resources delete -d ./unwanted-resources/
+	grafanactl resources delete -p ./unwanted-resources/
 
 	# Delete every dashboard defined in the given directory
-	grafanactl resources delete -d ./unwanted-resources/ dashboard
+	grafanactl resources delete -p ./unwanted-resources/ dashboard
 
 ```
 
 ### Options
 
 ```
-  -d, --directory strings    Directories on disk containing the resources to delete
       --dry-run              If set, the delete operation will be simulated
       --force                Delete all resources of the specified resource types
   -h, --help                 help for delete
       --max-concurrent int   Maximum number of concurrent operations (default 10)
+  -p, --path strings         Path on disk containing the resources to delete
       --stop-on-error        Stop pulling resources when an error occurs
 ```
 

--- a/docs/reference/cli/grafanactl_resources_pull.md
+++ b/docs/reference/cli/grafanactl_resources_pull.md
@@ -56,10 +56,10 @@ grafanactl resources pull [RESOURCE_SELECTOR]... [flags]
 ### Options
 
 ```
-  -d, --directory string   Directory on disk in which the resources will be written. (default "./resources")
-  -h, --help               help for pull
-  -o, --output string      Output format. One of: json, yaml (default "json")
-      --stop-on-error      Stop pulling resources when an error occurs
+  -h, --help            help for pull
+  -o, --output string   Output format. One of: json, yaml (default "json")
+  -p, --path string     Path on disk in which the resources will be written. (default "./resources")
+      --stop-on-error   Stop pulling resources when an error occurs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/grafanactl_resources_push.md
+++ b/docs/reference/cli/grafanactl_resources_push.md
@@ -56,10 +56,10 @@ grafanactl resources push [RESOURCE_SELECTOR]... [flags]
 ### Options
 
 ```
-  -d, --directory strings    Directories on disk from which to read the resources to push (default [./resources])
       --dry-run              If set, the push operation will be simulated, without actually creating or updating any resources
   -h, --help                 help for push
       --max-concurrent int   Maximum number of concurrent operations (default 10)
+  -p, --path strings         Paths on disk from which to read the resources to push (default [./resources])
       --stop-on-error        Stop pushing resources when an error occurs
 ```
 

--- a/docs/reference/cli/grafanactl_resources_validate.md
+++ b/docs/reference/cli/grafanactl_resources_validate.md
@@ -37,10 +37,10 @@ grafanactl resources validate [RESOURCE_SELECTOR]... [flags]
 ### Options
 
 ```
-  -d, --directory strings    Directories on disk from which to read the resources. (default [./resources])
   -h, --help                 help for validate
       --max-concurrent int   Maximum number of concurrent operations (default 10)
   -o, --output string        Output format. One of: json, text, yaml (default "text")
+  -p, --path strings         Paths on disk from which to read the resources. (default [./resources])
       --stop-on-error        Stop validating resources when an error occurs
 ```
 

--- a/internal/resources/local/writer.go
+++ b/internal/resources/local/writer.go
@@ -30,8 +30,8 @@ func GroupResourcesByKind(extension string) FileNamer {
 }
 
 type FSWriter struct {
-	// Directory on the filesystem where resources should be written.
-	Directory string
+	// Path on the filesystem where resources should be written.
+	Path string
 	// Namer is a function mapping a resource to a path on the filesystem
 	// (relative to Directory).
 	// The naming strategy used here directly controls the file hierarchy created
@@ -49,11 +49,11 @@ func (writer *FSWriter) Write(ctx context.Context, resources *resources.Resource
 		return nil
 	}
 
-	logger := logging.FromContext(ctx).With(slog.String("directory", writer.Directory))
+	logger := logging.FromContext(ctx).With(slog.String("path", writer.Path))
 	logger.Debug("Writing resources", slog.Int("resources", resources.Len()))
 
 	// Create the directory if it doesn't exist
-	if err := ensureDirectoryExists(writer.Directory); err != nil {
+	if err := ensureDirectoryExists(writer.Path); err != nil {
 		return err
 	}
 
@@ -76,7 +76,7 @@ func (writer *FSWriter) writeSingle(resource *resources.Resource) error {
 		return fmt.Errorf("could not generate resource path: %w", err)
 	}
 
-	fullFileName := filepath.Join(writer.Directory, filename)
+	fullFileName := filepath.Join(writer.Path, filename)
 	if err := ensureDirectoryExists(filepath.Dir(fullFileName)); err != nil {
 		return fmt.Errorf("could ensure resource directory exists: %w", err)
 	}

--- a/internal/resources/local/writer_test.go
+++ b/internal/resources/local/writer_test.go
@@ -17,8 +17,8 @@ func TestFSWriter_Write(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "output")
 
 	writer := local.FSWriter{
-		Directory: outputDir,
-		Encoder:   format.NewYAMLCodec(),
+		Path:    outputDir,
+		Encoder: format.NewYAMLCodec(),
 		Namer: func(resource *resources.Resource) (string, error) {
 			return resource.Name() + ".yaml", nil
 		},
@@ -36,7 +36,7 @@ func TestFSWriter_Write_continueOnError(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "output")
 
 	writer := local.FSWriter{
-		Directory:   outputDir,
+		Path:        outputDir,
 		Encoder:     format.NewYAMLCodec(),
 		StopOnError: false,
 		Namer: func(resource *resources.Resource) (string, error) {
@@ -59,9 +59,9 @@ func TestFSWriter_Write_groupedByKind(t *testing.T) {
 	outputDir := filepath.Join(t.TempDir(), "output")
 
 	writer := local.FSWriter{
-		Directory: outputDir,
-		Encoder:   format.NewJSONCodec(),
-		Namer:     local.GroupResourcesByKind("json"),
+		Path:    outputDir,
+		Encoder: format.NewJSONCodec(),
+		Namer:   local.GroupResourcesByKind("json"),
 	}
 
 	err := writer.Write(t.Context(), testResources())
@@ -80,8 +80,8 @@ func TestFSWriter_Write_doesNothingWithNoResources(t *testing.T) {
 	req.NoError(err)
 
 	writer := local.FSWriter{
-		Directory: outputDir,
-		Encoder:   format.NewYAMLCodec(),
+		Path:    outputDir,
+		Encoder: format.NewYAMLCodec(),
 		Namer: func(resource *resources.Resource) (string, error) {
 			return resource.Name() + ".yaml", nil
 		},


### PR DESCRIPTION
### What

This commit changes how `resources pull / push / validate` interact with the FS.

Rather than working with directories only, they now all work with arbitrary paths (which could be either directories or files).

That said, `resources push` will expect the `--path` argument to be a directory (and will error out otherwise) because we do not support writing (or reading) multiple resources into one file at the moment.

However, for the sake of consistency it uses the same option name.

### Why

To make it possible to push & validate individual files instead of just directories.