### PR TITLE
Support dynamic switching of versions

### DIFF
--- a/internal/resources/dynamic/namespaced_client.go
+++ b/internal/resources/dynamic/namespaced_client.go
@@ -1,4 +1,4 @@
-package client
+package dynamic
 
 import (
 	"context"
@@ -11,32 +11,32 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
-// NamespacedDynamicClient is a dynamic client with a namespace and a discovery registry.
-type NamespacedDynamicClient struct {
+// NamespacedClient is a dynamic client with a namespace and a discovery registry.
+type NamespacedClient struct {
 	namespace string
 	client    dynamic.Interface
 }
 
-// NewDefaultNamespacedDynamicClient creates a new namespaced dynamic client using the default discovery registry.
-func NewDefaultNamespacedDynamicClient(cfg config.NamespacedRESTConfig) (*NamespacedDynamicClient, error) {
+// NewDefaultNamespacedClient creates a new namespaced dynamic client using the default discovery registry.
+func NewDefaultNamespacedClient(cfg config.NamespacedRESTConfig) (*NamespacedClient, error) {
 	client, err := dynamic.NewForConfig(&cfg.Config)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewNamespacedDynamicClient(cfg.Namespace, client), nil
+	return NewNamespacedClient(cfg.Namespace, client), nil
 }
 
-// NewNamespacedDynamicClient creates a new namespaced dynamic client.
-func NewNamespacedDynamicClient(namespace string, client dynamic.Interface) *NamespacedDynamicClient {
-	return &NamespacedDynamicClient{
+// NewNamespacedClient creates a new namespaced dynamic client.
+func NewNamespacedClient(namespace string, client dynamic.Interface) *NamespacedClient {
+	return &NamespacedClient{
 		client:    client,
 		namespace: namespace,
 	}
 }
 
 // List lists resources from the server.
-func (c *NamespacedDynamicClient) List(
+func (c *NamespacedClient) List(
 	ctx context.Context, desc resources.Descriptor, opts metav1.ListOptions,
 ) (*unstructured.UnstructuredList, error) {
 	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).List(ctx, opts)
@@ -49,7 +49,7 @@ func (c *NamespacedDynamicClient) List(
 //
 // Ideally we'd like to use field selectors,
 // but Kubernetes does not support set-based operators in field selectors (only in labels).
-func (c *NamespacedDynamicClient) GetMultiple(
+func (c *NamespacedClient) GetMultiple(
 	ctx context.Context, desc resources.Descriptor, names []string, opts metav1.ListOptions,
 ) ([]unstructured.Unstructured, error) {
 	res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).List(ctx, opts)
@@ -70,35 +70,35 @@ func (c *NamespacedDynamicClient) GetMultiple(
 }
 
 // Get gets a resource from the server.
-func (c *NamespacedDynamicClient) Get(
+func (c *NamespacedClient) Get(
 	ctx context.Context, desc resources.Descriptor, name string, opts metav1.GetOptions,
 ) (*unstructured.Unstructured, error) {
 	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Get(ctx, name, opts)
 }
 
 // Create creates a resource on the server.
-func (c *NamespacedDynamicClient) Create(
+func (c *NamespacedClient) Create(
 	ctx context.Context, desc resources.Descriptor, obj *unstructured.Unstructured, opts metav1.CreateOptions,
 ) (*unstructured.Unstructured, error) {
 	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Create(ctx, obj, opts)
 }
 
 // Update updates a resource on the server.
-func (c *NamespacedDynamicClient) Update(
+func (c *NamespacedClient) Update(
 	ctx context.Context, desc resources.Descriptor, obj *unstructured.Unstructured, opts metav1.UpdateOptions,
 ) (*unstructured.Unstructured, error) {
 	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Update(ctx, obj, opts)
 }
 
 // Delete deletes a resource on the server.
-func (c *NamespacedDynamicClient) Delete(
+func (c *NamespacedClient) Delete(
 	ctx context.Context, desc resources.Descriptor, name string, opts metav1.DeleteOptions,
 ) error {
 	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Delete(ctx, name, opts)
 }
 
 // Apply applies a resource on the server.
-func (c *NamespacedDynamicClient) Apply(
+func (c *NamespacedClient) Apply(
 	ctx context.Context, desc resources.Descriptor, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions,
 ) (*unstructured.Unstructured, error) {
 	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Apply(ctx, name, obj, opts)

--- a/internal/resources/dynamic/versioned_client.go
+++ b/internal/resources/dynamic/versioned_client.go
@@ -1,0 +1,176 @@
+package dynamic
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafanactl/internal/config"
+	"github.com/grafana/grafanactl/internal/resources"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// VersionedClient is a dynamic client that supports automatic version switching.
+// It will automatically switch to the correct version of the resource based on the stored version.
+type VersionedClient struct {
+	*NamespacedClient
+}
+
+// NewDefaultVersionedClient creates a new versioned client using the default namespaced client.
+func NewDefaultVersionedClient(cfg config.NamespacedRESTConfig) (*VersionedClient, error) {
+	client, err := NewDefaultNamespacedClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return WrapNamespacedClient(client), nil
+}
+
+// WrapNamespacedClient wraps a namespaced client in a versioned client.
+func WrapNamespacedClient(client *NamespacedClient) *VersionedClient {
+	return &VersionedClient{
+		NamespacedClient: client,
+	}
+}
+
+// List lists resources from the server.
+// It will automatically re-fetch resources which need to be fetched using the stored version.
+func (c *VersionedClient) List(
+	ctx context.Context, desc resources.Descriptor, opts metav1.ListOptions,
+) (*unstructured.UnstructuredList, error) {
+	list, err := c.NamespacedClient.List(ctx, desc, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.getMultipleCorrectVersions(ctx, desc, list.Items, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Replace the items in the original list with the new ones and return it.
+	list.Items = res
+	return list, nil
+}
+
+// GetMultiple gets multiple resources from the server.
+// It will automatically re-fetch resources which need to be fetched using the stored version.
+func (c *VersionedClient) GetMultiple(
+	ctx context.Context, desc resources.Descriptor, names []string, opts metav1.ListOptions,
+) ([]unstructured.Unstructured, error) {
+	objs, err := c.NamespacedClient.GetMultiple(ctx, desc, names, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.getMultipleCorrectVersions(ctx, desc, objs, opts)
+}
+
+// Get gets a resource from the server.
+func (c *VersionedClient) Get(
+	ctx context.Context, desc resources.Descriptor, name string, opts metav1.GetOptions,
+) (*unstructured.Unstructured, error) {
+	obj, err := c.NamespacedClient.Get(ctx, desc, name, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	storedVersion, err := getStoredVersion(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	if storedVersion == "" {
+		return obj, nil
+	}
+
+	newdesc := desc
+	newdesc.GroupVersion.Version = storedVersion
+
+	return c.NamespacedClient.Get(ctx, newdesc, name, opts)
+}
+
+func (c *VersionedClient) getMultipleCorrectVersions(
+	ctx context.Context, desc resources.Descriptor, src []unstructured.Unstructured, opts metav1.ListOptions,
+) ([]unstructured.Unstructured, error) {
+	res := make([]unstructured.Unstructured, 0, len(src))
+	versioned := make(map[resources.Descriptor][]string)
+
+	// Iterate over all objects and check if they need to be re-fetched using the stored version.
+	// Group the objects by the new descriptor.
+	for _, obj := range src {
+		storedVersion, err := getStoredVersion(&obj)
+		if err != nil {
+			return nil, err
+		}
+
+		if storedVersion == "" {
+			res = append(res, obj)
+			continue
+		}
+
+		newdesc := desc
+		newdesc.GroupVersion.Version = storedVersion
+		if _, ok := versioned[newdesc]; !ok {
+			versioned[newdesc] = make([]string, 0, len(src))
+		}
+		versioned[newdesc] = append(versioned[newdesc], obj.GetName())
+	}
+
+	// If there are no versioned objects, we can return the original list.
+	if len(versioned) == 0 {
+		return src, nil
+	}
+
+	// Iterate over all descriptors we need to re-fetch,
+	// fetch them using GetMultiple and append the results to the result list.
+	for desc, names := range versioned {
+		objs, err := c.GetMultiple(ctx, desc, names, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		res = append(res, objs...)
+	}
+
+	return res, nil
+}
+
+func getStoredVersion(obj *unstructured.Unstructured) (string, error) {
+	acc, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return "", err
+	}
+
+	stat, err := acc.GetStatus()
+	if err != nil {
+		return "", err
+	}
+
+	statm, ok := stat.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+
+	conv, ok := statm["conversion"]
+	if !ok {
+		return "", nil
+	}
+
+	convm, ok := conv.(map[string]any)
+	if !ok {
+		return "", nil
+	}
+
+	v, ok := convm["storedVersion"]
+	if !ok {
+		return "", nil
+	}
+
+	storedVersion, ok := v.(string)
+	if !ok {
+		return "", nil
+	}
+
+	return storedVersion, nil
+}

--- a/internal/resources/remote/deleter.go
+++ b/internal/resources/remote/deleter.go
@@ -8,21 +8,21 @@ import (
 	"github.com/grafana/grafanactl/internal/config"
 	"github.com/grafana/grafanactl/internal/logs"
 	"github.com/grafana/grafanactl/internal/resources"
-	"github.com/grafana/grafanactl/internal/resources/client"
 	"github.com/grafana/grafanactl/internal/resources/discovery"
+	"github.com/grafana/grafanactl/internal/resources/dynamic"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // Deleter takes care of deleting resources from Grafana.
 type Deleter struct {
-	client   *client.NamespacedDynamicClient
+	client   *dynamic.NamespacedClient
 	registry PushRegistry
 }
 
 // NewDeleter creates a new Deleter.
 func NewDeleter(ctx context.Context, cfg config.NamespacedRESTConfig) (*Deleter, error) {
-	cli, err := client.NewDefaultNamespacedDynamicClient(cfg)
+	cli, err := dynamic.NewDefaultNamespacedClient(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resources/remote/puller.go
+++ b/internal/resources/remote/puller.go
@@ -8,8 +8,8 @@ import (
 	"github.com/grafana/grafanactl/internal/config"
 	"github.com/grafana/grafanactl/internal/logs"
 	"github.com/grafana/grafanactl/internal/resources"
-	"github.com/grafana/grafanactl/internal/resources/client"
 	"github.com/grafana/grafanactl/internal/resources/discovery"
+	"github.com/grafana/grafanactl/internal/resources/dynamic"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -43,7 +43,7 @@ type Puller struct {
 
 // NewDefaultPuller creates a new Puller.
 func NewDefaultPuller(ctx context.Context, restConfig config.NamespacedRESTConfig) (*Puller, error) {
-	client, err := client.NewDefaultNamespacedDynamicClient(restConfig)
+	client, err := dynamic.NewDefaultVersionedClient(restConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resources/remote/pusher.go
+++ b/internal/resources/remote/pusher.go
@@ -9,8 +9,8 @@ import (
 	"github.com/grafana/grafanactl/internal/config"
 	"github.com/grafana/grafanactl/internal/logs"
 	"github.com/grafana/grafanactl/internal/resources"
-	"github.com/grafana/grafanactl/internal/resources/client"
 	"github.com/grafana/grafanactl/internal/resources/discovery"
+	"github.com/grafana/grafanactl/internal/resources/dynamic"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -46,7 +46,7 @@ type Pusher struct {
 // NewDefaultPusher creates a new Pusher.
 // It uses the default namespaced dynamic client to push resources to Grafana.
 func NewDefaultPusher(ctx context.Context, cfg config.NamespacedRESTConfig) (*Pusher, error) {
-	client, err := client.NewDefaultNamespacedDynamicClient(cfg)
+	client, err := dynamic.NewDefaultNamespacedClient(cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What

Add a new client implementation that supports automatically switching versions for each object, depending on what is stored in the API.

### Why

For some resources we need to fetch them using their stored versions.