### PR TITLE
Fix underline length in config check command

### DIFF
--- a/cmd/grafanactl/config/command.go
+++ b/cmd/grafanactl/config/command.go
@@ -308,7 +308,9 @@ func checkCmd(configOpts *Options) *cobra.Command {
 
 func checkContext(cmd *cobra.Command, gCtx *config.Context) {
 	stdout := cmd.OutOrStdout()
-	title := "Context: " + io.Bold(gCtx.Name)
+	title := "Context: "
+	titleLen := len(title) + len(gCtx.Name)
+	title += io.Bold(gCtx.Name)
 
 	summarizeError := func(err error) string {
 		detailedErr := fail.ErrorToDetailedError(err)
@@ -328,7 +330,7 @@ func checkContext(cmd *cobra.Command, gCtx *config.Context) {
 	}
 
 	cmd.Println(io.Yellow(title))
-	cmd.Println(io.Yellow(strings.Repeat("=", len(title))))
+	cmd.Println(io.Yellow(strings.Repeat("=", titleLen)))
 
 	if err := gCtx.Validate(); err != nil {
 		io.Error(stdout, "Configuration: %s", io.Red(summarizeError(err)))


### PR DESCRIPTION
Before:

![Screenshot From 2025-05-01 23-54-43](https://github.com/user-attachments/assets/893053be-122d-4b99-bdce-e0f2714c822e)

After:

![context_default_ok](https://github.com/user-attachments/assets/29d52591-6dba-44dc-8e7a-96bc3b3dc19b)

To have a correct underline for context names, the length of the title must be calculated before parts of the title are set to bold.