### PR TITLE
Implement proper resource management

### DIFF
--- a/cmd/grafanactl/resources/edit.go
+++ b/cmd/grafanactl/resources/edit.go
@@ -107,12 +107,8 @@ The edition will be cancelled if no changes are written to the file or if the fi
 				return fmt.Errorf("expected exactly one resource, got %d", len(list))
 			}
 
-			obj, err := list[0].ToUnstructured()
-			if err != nil {
-				return err
-			}
-
-			if err := codec.Encode(buffer, obj); err != nil {
+			obj := list[0].ToUnstructured()
+			if err := codec.Encode(buffer, &obj); err != nil {
 				return err
 			}
 

--- a/cmd/grafanactl/resources/fetch.go
+++ b/cmd/grafanactl/resources/fetch.go
@@ -13,7 +13,9 @@ import (
 type fetchRequest struct {
 	Config             config.NamespacedRESTConfig
 	StopOnError        bool
+	ExcludeManaged     bool
 	ExpectSingleTarget bool
+	Processors         []remote.Processor
 }
 
 type fetchResponse struct {
@@ -54,9 +56,11 @@ func fetchResources(ctx context.Context, opts fetchRequest, args []string) (*fet
 	}
 
 	req := remote.PullRequest{
-		Filters:     filters,
-		StopOnError: opts.StopOnError || sels.IsSingleTarget(),
-		Resources:   &res.Resources,
+		Filters:        filters,
+		Resources:      &res.Resources,
+		Processors:     opts.Processors,
+		ExcludeManaged: opts.ExcludeManaged,
+		StopOnError:    opts.StopOnError || sels.IsSingleTarget(),
 	}
 
 	if err := pull.Pull(ctx, req); err != nil {

--- a/docs/reference/cli/grafanactl_resources_pull.md
+++ b/docs/reference/cli/grafanactl_resources_pull.md
@@ -56,10 +56,11 @@ grafanactl resources pull [RESOURCE_SELECTOR]... [flags]
 ### Options
 
 ```
-  -h, --help            help for pull
-  -o, --output string   Output format. One of: json, yaml (default "json")
-  -p, --path string     Path on disk in which the resources will be written. (default "./resources")
-      --stop-on-error   Stop pulling resources when an error occurs
+  -h, --help              help for pull
+      --include-managed   Include resources managed by tools other than grafanactl
+  -o, --output string     Output format. One of: json, yaml (default "json")
+  -p, --path string       Path on disk in which the resources will be written (default "./resources")
+      --stop-on-error     Stop pulling resources when an error occurs
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/grafanactl_resources_push.md
+++ b/docs/reference/cli/grafanactl_resources_push.md
@@ -56,11 +56,13 @@ grafanactl resources push [RESOURCE_SELECTOR]... [flags]
 ### Options
 
 ```
-      --dry-run              If set, the push operation will be simulated, without actually creating or updating any resources
-  -h, --help                 help for push
-      --max-concurrent int   Maximum number of concurrent operations (default 10)
-  -p, --path strings         Paths on disk from which to read the resources to push (default [./resources])
-      --stop-on-error        Stop pushing resources when an error occurs
+      --dry-run               If set, the push operation will be simulated, without actually creating or updating any resources
+  -h, --help                  help for push
+      --include-managed       If set, resources managed by other tools will be included in the push operation
+      --max-concurrent int    Maximum number of concurrent operations (default 10)
+      --omit-manager-fields   If set, the manager fields will not be appended to the resources
+  -p, --path strings          Paths on disk from which to read the resources to push (default [./resources])
+      --stop-on-error         Stop pushing resources when an error occurs
 ```
 
 ### Options inherited from parent commands

--- a/internal/resources/filter_test.go
+++ b/internal/resources/filter_test.go
@@ -27,7 +27,7 @@ func TestFilter_Matches(t *testing.T) {
 		"spec": map[string]any{
 			"uid": "test-1",
 		},
-	})
+	}, resources.SourceInfo{})
 
 	folder := resources.MustFromObject(map[string]any{
 		"apiVersion": "folder.grafana.app/v1",
@@ -38,7 +38,7 @@ func TestFilter_Matches(t *testing.T) {
 		"spec": map[string]any{
 			"title": "test-3",
 		},
-	})
+	}, resources.SourceInfo{})
 
 	tests := []struct {
 		name     string

--- a/internal/resources/local/writer.go
+++ b/internal/resources/local/writer.go
@@ -88,15 +88,11 @@ func (writer *FSWriter) writeSingle(resource *resources.Resource) error {
 	}
 	defer file.Close()
 
-	obj, err := resource.ToUnstructured()
-	if err != nil {
-		return fmt.Errorf("could not convert resource to unstructured: %w", err)
-	}
-
+	obj := resource.ToUnstructured()
 	// MarshalJSON() methods for [unstructured.UnstructuredList] and
 	// [unstructured.Unstructured] types are defined on pointer receivers,
 	// so we need to make sure we dereference `resource` before formatting it.
-	if err := writer.Encoder.Encode(file, obj); err != nil {
+	if err := writer.Encoder.Encode(file, &obj); err != nil {
 		return fmt.Errorf("could write resource: %w", err)
 	}
 

--- a/internal/resources/process/managerfields.go
+++ b/internal/resources/process/managerfields.go
@@ -1,0 +1,35 @@
+package process
+
+import (
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafanactl/internal/resources"
+)
+
+// ManagerFieldsAppender is a processor that appends manager and source fields to a resource.
+// It will return an error if the resource is already managed by another manager.
+type ManagerFieldsAppender struct {
+}
+
+func (m *ManagerFieldsAppender) Process(r *resources.Resource) error {
+	if r.IsEmpty() {
+		return nil
+	}
+
+	if !r.IsManaged() {
+		// If the resource is not managed by grafanactl,
+		// we don't want to set the manager fields.
+		return nil
+	}
+
+	r.Raw.SetManagerProperties(utils.ManagerProperties{
+		Kind:     resources.ResourceManagerKind,
+		Identity: "grafanactl", // TODO: use version information to set the identity.
+	})
+
+	// TODO: should we set timestamp & checksum as well?
+	r.Raw.SetSourceProperties(utils.SourceProperties{
+		Path: r.Source.String(),
+	})
+
+	return nil
+}

--- a/internal/resources/process/managerfields_test.go
+++ b/internal/resources/process/managerfields_test.go
@@ -1,0 +1,159 @@
+package process_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafanactl/internal/resources"
+	"github.com/grafana/grafanactl/internal/resources/process"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestManagerFieldsAppender(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   *resources.Resource
+		want    unstructured.Unstructured
+		wantErr bool
+	}{
+		{
+			name:    "empty resource",
+			input:   &resources.Resource{},
+			want:    unstructured.Unstructured{},
+			wantErr: false,
+		},
+		{
+			name: "resource with no manager fields",
+			input: resources.MustFromObject(
+				map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "default",
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+				resources.SourceInfo{
+					Path: "some/test/path.json",
+				},
+			),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "default",
+						"annotations": map[string]any{
+							utils.AnnoKeyManagerKind:     string(resources.ResourceManagerKind),
+							utils.AnnoKeyManagerIdentity: "grafanactl",
+							utils.AnnoKeySourcePath:      "file://some/test/path.json",
+						},
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "resource managed by Terraform",
+			input: resources.MustFromObject(map[string]any{
+				"apiVersion": "dashboard.grafana.app/v1",
+				"kind":       "Dashboard",
+				"metadata": map[string]any{
+					"name":      "example",
+					"namespace": "default",
+					"annotations": map[string]any{
+						utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+						utils.AnnoKeyManagerIdentity: "terraform-version-1",
+						utils.AnnoKeySourcePath:      "resource.tf",
+					},
+				},
+				"spec": map[string]any{
+					"title": "example",
+				},
+			}, resources.SourceInfo{}),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "default",
+						"annotations": map[string]any{
+							utils.AnnoKeyManagerKind:     string(utils.ManagerKindTerraform),
+							utils.AnnoKeyManagerIdentity: "terraform-version-1",
+							utils.AnnoKeySourcePath:      "resource.tf",
+						},
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "resource managed by grafanactl",
+			input: resources.MustFromObject(
+				map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "default",
+						"annotations": map[string]any{
+							utils.AnnoKeyManagerIdentity: "grafanactl",
+							utils.AnnoKeyManagerKind:     string(resources.ResourceManagerKind),
+							utils.AnnoKeySourcePath:      "file://some/test/path.json",
+						},
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+				resources.SourceInfo{
+					Path: "other/test/path.json",
+				},
+			),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "default",
+						"annotations": map[string]any{
+							utils.AnnoKeyManagerKind:     string(resources.ResourceManagerKind),
+							utils.AnnoKeyManagerIdentity: "grafanactl",
+							utils.AnnoKeySourcePath:      "file://other/test/path.json",
+						},
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			appender := &process.ManagerFieldsAppender{}
+			err := appender.Process(test.input)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.Equal(t, test.want, test.input.ToUnstructured())
+		})
+	}
+}

--- a/internal/resources/process/serverfields.go
+++ b/internal/resources/process/serverfields.go
@@ -10,47 +10,53 @@ import (
 type ServerFieldsStripper struct{}
 
 // Process strips server-side fields from resources.
-func (m *ServerFieldsStripper) Process(src *resources.Resources) (*resources.Resources, error) {
-	list := unstructured.UnstructuredList{
-		Items: make([]unstructured.Unstructured, 0, src.Len()),
-	}
-
-	if err := src.ForEach(func(r *resources.Resource) error {
-		spec, err := r.Raw.GetSpec()
-		if err != nil {
-			return err
-		}
-
-		// Remove annotations set by the server.
-		annotations := r.Raw.GetAnnotations()
-		delete(annotations, utils.AnnoKeyCreatedBy)
-		delete(annotations, utils.AnnoKeyUpdatedBy)
-		delete(annotations, utils.AnnoKeyUpdatedTimestamp)
-
-		// Remove labels set by the server.
-		labels := r.Raw.GetLabels()
-		delete(labels, utils.LabelKeyDeprecatedInternalID)
-
-		list.Items = append(list.Items, unstructured.Unstructured{
-			Object: map[string]any{
-				"apiVersion": r.APIVersion(),
-				"kind":       r.Kind(),
-				"metadata": map[string]any{
-					"name":        r.Name(),
-					"namespace":   r.Namespace(),
-					"annotations": annotations,
-					"labels":      labels,
-				},
-				"spec": spec,
-			},
-		})
-
+func (m *ServerFieldsStripper) Process(r *resources.Resource) error {
+	if r.IsEmpty() {
 		return nil
-	}); err != nil {
-		return nil, err
 	}
 
-	return resources.NewResourcesFromUnstructured(list)
+	spec, err := r.Spec()
+	if err != nil {
+		return err
+	}
+
+	// Remove annotations set by the server.
+	annotations := r.Annotations()
+	delete(annotations, utils.AnnoKeyCreatedBy)
+	delete(annotations, utils.AnnoKeyUpdatedBy)
+	delete(annotations, utils.AnnoKeyUpdatedTimestamp)
+
+	// Remove manager fields & source properties if the resource is managed by grafanactl,
+	// because these fields are automatically set on push.
+	p, ok := r.Raw.GetManagerProperties()
+	if ok && p.Kind == resources.ResourceManagerKind {
+		delete(annotations, utils.AnnoKeyManagerKind)
+		delete(annotations, utils.AnnoKeyManagerIdentity)
+		delete(annotations, utils.AnnoKeyManagerSuspended)
+		delete(annotations, utils.AnnoKeyManagerAllowsEdits)
+
+		delete(annotations, utils.AnnoKeySourcePath)
+		delete(annotations, utils.AnnoKeySourceChecksum)
+		delete(annotations, utils.AnnoKeySourceTimestamp)
+	}
+
+	// Remove labels set by the server.
+	labels := r.Labels()
+	delete(labels, utils.LabelKeyDeprecatedInternalID)
+
+	return r.SetUnstructured(&unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": r.APIVersion(),
+			"kind":       r.Kind(),
+			"metadata": map[string]any{
+				"name":        r.Name(),
+				"namespace":   r.Namespace(),
+				"annotations": annotations,
+				"labels":      labels,
+			},
+			"spec": spec,
+		},
+	})
 }
 
 // Name returns the name of the processor.

--- a/internal/resources/process/serverfields_test.go
+++ b/internal/resources/process/serverfields_test.go
@@ -7,52 +7,51 @@ import (
 	"github.com/grafana/grafanactl/internal/resources"
 	"github.com/grafana/grafanactl/internal/resources/process"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestServerFieldsStripper_Process(t *testing.T) {
 	tests := []struct {
 		name    string
-		input   *resources.Resources
-		want    *resources.Resources
+		input   *resources.Resource
+		want    unstructured.Unstructured
 		wantErr bool
 	}{
 		{
-			name:    "no resources",
-			input:   resources.NewResources(),
-			want:    resources.NewResources(),
+			name:    "empty resource",
+			input:   &resources.Resource{},
+			want:    unstructured.Unstructured{},
 			wantErr: false,
 		},
 		{
-			name: "one resource",
-			input: resources.NewResources(
-				resources.MustFromObject(map[string]any{
-					"apiVersion": "dashboard.grafana.app/v1",
-					"kind":       "Dashboard",
-					"metadata": map[string]any{
-						"name":              "example",
-						"namespace":         "default",
-						"uid":               "test",
-						"generation":        1,
-						"resourceVersion":   "1",
-						"creationTimestamp": "2021-01-01T00:00:00Z",
-						"annotations": map[string]any{
-							utils.AnnoKeyCreatedBy:        "test",
-							utils.AnnoKeyUpdatedBy:        "test",
-							utils.AnnoKeyUpdatedTimestamp: "2021-01-01T00:00:00Z",
-							"test-annotation":             "test",
-						},
-						"labels": map[string]any{
-							utils.LabelKeyDeprecatedInternalID: "test",
-							"test-label":                       "test",
-						},
+			name: "resource with server fields",
+			input: resources.MustFromObject(map[string]any{
+				"apiVersion": "dashboard.grafana.app/v1",
+				"kind":       "Dashboard",
+				"metadata": map[string]any{
+					"name":              "example",
+					"namespace":         "default",
+					"uid":               "test",
+					"generation":        1,
+					"resourceVersion":   "1",
+					"creationTimestamp": "2021-01-01T00:00:00Z",
+					"annotations": map[string]any{
+						utils.AnnoKeyCreatedBy:        "test",
+						utils.AnnoKeyUpdatedBy:        "test",
+						utils.AnnoKeyUpdatedTimestamp: "2021-01-01T00:00:00Z",
+						"test-annotation":             "test",
 					},
-					"spec": map[string]any{
-						"foo": "bar",
+					"labels": map[string]any{
+						utils.LabelKeyDeprecatedInternalID: "test",
+						"test-label":                       "test",
 					},
-				}),
-			),
-			want: resources.NewResources(
-				resources.MustFromObject(map[string]any{
+				},
+				"spec": map[string]any{
+					"foo": "bar",
+				},
+			}, resources.SourceInfo{}),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
 					"apiVersion": "dashboard.grafana.app/v1",
 					"kind":       "Dashboard",
 					"metadata": map[string]any{
@@ -68,8 +67,8 @@ func TestServerFieldsStripper_Process(t *testing.T) {
 					"spec": map[string]any{
 						"foo": "bar",
 					},
-				}),
-			),
+				},
+			},
 			wantErr: false,
 		},
 	}
@@ -77,14 +76,13 @@ func TestServerFieldsStripper_Process(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			proc := &process.ServerFieldsStripper{}
-			actual, err := proc.Process(test.input)
+			err := proc.Process(test.input)
 			if test.wantErr {
 				require.Error(t, err)
 				return
 			}
 
-			require.NoError(t, err)
-			require.Equal(t, actual.ToUnstructuredList(), test.want.ToUnstructuredList())
+			require.Equal(t, test.want, test.input.ToUnstructured())
 		})
 	}
 }

--- a/internal/resources/remote/remote.go
+++ b/internal/resources/remote/remote.go
@@ -1,0 +1,12 @@
+package remote
+
+import "github.com/grafana/grafanactl/internal/resources"
+
+// Processor can be used to modify a resource in-place,
+// before it is written or after it is read from local sources.
+//
+// They can be used to e.g. strip server-side fields from a resource,
+// or add extra metadata after a resource has been read from a file.
+type Processor interface {
+	Process(res *resources.Resource) error
+}

--- a/internal/server/handlers/dashboards-proxy.go
+++ b/internal/server/handlers/dashboards-proxy.go
@@ -202,7 +202,7 @@ func (c *DashboardProxy) dashboardJSONPostHandler() http.HandlerFunc {
 		defer file.Close()
 
 		var codec format.Encoder = format.NewJSONCodec()
-		if resource.SourceFormat() == "yaml" {
+		if resource.SourceFormat() == format.YAML {
 			codec = format.NewYAMLCodec()
 		}
 


### PR DESCRIPTION
### What

This commit implements proper resource management logic, specifically:

* Resources are now stamped with extra manager & source annotations on `push`
* Resources managed by other managers get special handling (excluded from pull & push by default)
* New flags added to override & modify this behaviour

Additionally I had to refactor how source tracking is done in `serve` to make sure it doesn't clash with other manager's source data.

### Why

This addresses https://github.com/grafana/grafanactl/issues/52 and https://github.com/grafana/grafanactl/issues/36.

We need to properly support resource management to avoid clashing with other managers and to enable new UX flows for managed resources in the UI in the future.