### PR TITLE
Fix: environment variables now override the current context instead of resetting it

### DIFF
--- a/cmd/grafanactl/config/command.go
+++ b/cmd/grafanactl/config/command.go
@@ -38,17 +38,18 @@ func (opts *Options) loadConfigTolerant(ctx context.Context, extraOverrides ...c
 		// If Grafana-related env variables are set, use them to configure the
 		// current context and Grafana config.
 		func(cfg *config.Config) error {
-			grafanaCfg := config.GrafanaConfig{}
-
-			if err := env.Parse(&grafanaCfg); err != nil {
-				return err
+			if cfg.CurrentContext == "" {
+				cfg.CurrentContext = config.DefaultContextName
 			}
 
-			if !grafanaCfg.IsEmpty() {
-				cfg.SetContext(config.DefaultContextName, true, config.Context{
-					Name:    config.DefaultContextName,
-					Grafana: &grafanaCfg,
-				})
+			if !cfg.HasContext(cfg.CurrentContext) {
+				cfg.SetContext(cfg.CurrentContext, true, config.Context{})
+			}
+
+			grafanaCfg := cfg.Contexts[cfg.CurrentContext]
+
+			if err := env.Parse(grafanaCfg); err != nil {
+				return err
 			}
 
 			return nil

--- a/cmd/grafanactl/config/command_test.go
+++ b/cmd/grafanactl/config/command_test.go
@@ -264,3 +264,26 @@ current-context: dev`),
 	}
 	viewCmd.Run(t)
 }
+
+func Test_ViewCommand_withEnvironmentVariables(t *testing.T) {
+	testCase := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"view", "--config", "testdata/partial-config.yaml", "--minify", "--raw"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+			testutils.CommandOutputEquals(`contexts:
+  prod:
+    grafana:
+      server: https://grafana.example.com/
+      token: token
+      org-id: 42
+current-context: prod
+`),
+		},
+		Env: map[string]string{
+			"GRAFANA_TOKEN": "token",
+		},
+	}
+
+	testCase.Run(t)
+}

--- a/cmd/grafanactl/config/testdata/partial-config.yaml
+++ b/cmd/grafanactl/config/testdata/partial-config.yaml
@@ -1,0 +1,11 @@
+contexts:
+  local:
+    grafana:
+      server: http://localhost:3000/
+      token: local_token
+  prod:
+    grafana:
+      server: https://grafana.example.com/
+      org-id: 42
+      #token: missing on purpose
+current-context: prod

--- a/internal/testutils/command.go
+++ b/internal/testutils/command.go
@@ -38,6 +38,14 @@ func CommandOutputContains(expected string) CommandAssertion {
 	}
 }
 
+func CommandOutputEquals(expected string) CommandAssertion {
+	return func(t *testing.T, result CommandResult) {
+		t.Helper()
+
+		require.Equal(t, expected, result.Stdout)
+	}
+}
+
 type CommandResult struct {
 	Err    error
 	Stdout string


### PR DESCRIPTION
Fixes #103

For some reason I decided that the use of environment variables should completely reset the current context.

The use-case described in #103 with *partial* config files and environment variables used to fill-in secrets seems completely valid to me, especially in a CI/CD setup.

This PR changes the way the configuration is loaded so environment variables override values in the current context without clearing it.