### PR TITLE
Include all supported versions when no specific version is provided in selectors

### DIFF
--- a/docs/reference/configuration/index.md
+++ b/docs/reference/configuration/index.md
@@ -40,7 +40,6 @@ contexts:
         # server is used.
         server-name: string
         # CertData holds PEM-encoded bytes (typically read from a client certificate file).
-        # CertData takes precedence over CertFile
         # Note: this value is base64-encoded in the config file and will be
         # automatically decoded.
         cert-data: 
@@ -48,7 +47,6 @@ contexts:
           - ...
           
         # KeyData holds PEM-encoded bytes (typically read from a client certificate key file).
-        # KeyData takes precedence over KeyFile
         # Note: this value is base64-encoded in the config file and will be
         # automatically decoded.
         key-data: 
@@ -56,7 +54,6 @@ contexts:
           - ...
           
         # CAData holds PEM-encoded bytes (typically read from a root certificates bundle).
-        # CAData takes precedence over CAFile
         # Note: this value is base64-encoded in the config file and will be
         # automatically decoded.
         ca-data: 

--- a/internal/resources/discovery/registry_test.go
+++ b/internal/resources/discovery/registry_test.go
@@ -20,7 +20,7 @@ func TestRegistry_MakeFilters(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:      "lookup with resource returns preferred version",
+			name:      "lookup with resource returns all supported versions",
 			discovery: getMixedVersionsDiscovery,
 			selectors: resources.Selectors{
 				{
@@ -32,6 +32,19 @@ func TestRegistry_MakeFilters(t *testing.T) {
 				},
 			},
 			want: resources.Filters{
+				{
+					Type:         resources.FilterTypeMultiple,
+					ResourceUIDs: []string{"foo", "bar"},
+					Descriptor: resources.Descriptor{
+						GroupVersion: schema.GroupVersion{
+							Group:   "dashboard.grafana.app",
+							Version: "v1",
+						},
+						Kind:     "Dashboard",
+						Plural:   "dashboards",
+						Singular: "dashboard",
+					},
+				},
 				{
 					Type:         resources.FilterTypeMultiple,
 					ResourceUIDs: []string{"foo", "bar"},
@@ -63,7 +76,7 @@ func TestRegistry_MakeFilters(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:      "lookup with single filter type",
+			name:      "lookup with single filter type returns all versions",
 			discovery: getMixedVersionsDiscovery,
 			selectors: resources.Selectors{
 				{
@@ -81,6 +94,19 @@ func TestRegistry_MakeFilters(t *testing.T) {
 					Descriptor: resources.Descriptor{
 						GroupVersion: schema.GroupVersion{
 							Group:   "dashboard.grafana.app",
+							Version: "v1",
+						},
+						Kind:     "Dashboard",
+						Plural:   "dashboards",
+						Singular: "dashboard",
+					},
+				},
+				{
+					Type:         resources.FilterTypeSingle,
+					ResourceUIDs: []string{"single-dashboard"},
+					Descriptor: resources.Descriptor{
+						GroupVersion: schema.GroupVersion{
+							Group:   "dashboard.grafana.app",
 							Version: "v2",
 						},
 						Kind:     "Dashboard",
@@ -92,7 +118,7 @@ func TestRegistry_MakeFilters(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "lookup with all filter type",
+			name:      "lookup with all filter type returns all versions",
 			discovery: getMixedVersionsDiscovery,
 			selectors: resources.Selectors{
 				{
@@ -119,7 +145,7 @@ func TestRegistry_MakeFilters(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "lookup with specific group and version",
+			name:      "lookup with specific group and version returns only that version",
 			discovery: getMixedVersionsDiscovery,
 			selectors: resources.Selectors{
 				{
@@ -148,7 +174,7 @@ func TestRegistry_MakeFilters(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "lookup with multiple selectors",
+			name:      "lookup with multiple selectors returns all versions for each",
 			discovery: getMixedVersionsDiscovery,
 			selectors: resources.Selectors{
 				{
@@ -166,6 +192,19 @@ func TestRegistry_MakeFilters(t *testing.T) {
 				},
 			},
 			want: resources.Filters{
+				{
+					Type:         resources.FilterTypeSingle,
+					ResourceUIDs: []string{"dashboard-1"},
+					Descriptor: resources.Descriptor{
+						GroupVersion: schema.GroupVersion{
+							Group:   "dashboard.grafana.app",
+							Version: "v1",
+						},
+						Kind:     "Dashboard",
+						Plural:   "dashboards",
+						Singular: "dashboard",
+					},
+				},
 				{
 					Type:         resources.FilterTypeSingle,
 					ResourceUIDs: []string{"dashboard-1"},
@@ -195,7 +234,7 @@ func TestRegistry_MakeFilters(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:      "lookup with kind instead of resource",
+			name:      "lookup with kind instead of resource returns all versions",
 			discovery: getMixedVersionsDiscovery,
 			selectors: resources.Selectors{
 				{
@@ -206,6 +245,18 @@ func TestRegistry_MakeFilters(t *testing.T) {
 				},
 			},
 			want: resources.Filters{
+				{
+					Type: resources.FilterTypeAll,
+					Descriptor: resources.Descriptor{
+						GroupVersion: schema.GroupVersion{
+							Group:   "dashboard.grafana.app",
+							Version: "v1",
+						},
+						Kind:     "Dashboard",
+						Plural:   "dashboards",
+						Singular: "dashboard",
+					},
+				},
 				{
 					Type: resources.FilterTypeAll,
 					Descriptor: resources.Descriptor{
@@ -241,7 +292,7 @@ func TestRegistry_MakeFilters(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, test.want, got)
+			assert.ElementsMatch(t, test.want, got)
 		})
 	}
 }


### PR DESCRIPTION
### What

Modify `MakeFilters` in `Registry` to return filters for all supported versions, when no specific version is provided in selectors, by using the new `LookupAllVersionsForPartialGVK` method from `RegistryIndex` to return all supported versions for a resource type.

### Why

Previously, when users ran `grafanactl resources push dashboard` without specifying an API version, only dashboards with the preferred version were pushed.

Dashboards with other versions (like `v0alpha1` when `v1beta1` was preferred) were ignored, because `MakeFilters` only returned a filter for the preferred version.

This fix ensures that when no specific version is provided in selectors, the command will push resources with ALL supported versions, preventing any resources from being ignored due to version mismatch.

Fixes #101