### PR TITLE
Correctly load config from the environment when no config file exists

### DIFF
--- a/cmd/grafanactl/config/command.go
+++ b/cmd/grafanactl/config/command.go
@@ -47,9 +47,13 @@ func (opts *Options) loadConfigTolerant(ctx context.Context, extraOverrides ...c
 				cfg.SetContext(cfg.CurrentContext, true, config.Context{})
 			}
 
-			grafanaCfg := cfg.Contexts[cfg.CurrentContext]
+			curCtx := cfg.Contexts[cfg.CurrentContext]
 
-			if err := env.Parse(grafanaCfg); err != nil {
+			if curCtx.Grafana == nil {
+				curCtx.Grafana = &config.GrafanaConfig{}
+			}
+
+			if err := env.Parse(curCtx); err != nil {
 				return err
 			}
 

--- a/cmd/grafanactl/config/command_test.go
+++ b/cmd/grafanactl/config/command_test.go
@@ -287,3 +287,26 @@ current-context: prod
 
 	testCase.Run(t)
 }
+
+func Test_ViewCommand_withEnvironmentVariablesAndNoConfig(t *testing.T) {
+	testCase := testutils.CommandTestCase{
+		Cmd:     config.Command(),
+		Command: []string{"view", "--minify", "--raw"},
+		Assertions: []testutils.CommandAssertion{
+			testutils.CommandSuccess(),
+			testutils.CommandOutputEquals(`contexts:
+  default:
+    grafana:
+      server: https://grafana.example.com/
+      token: token
+current-context: default
+`),
+		},
+		Env: map[string]string{
+			"GRAFANA_SERVER": "https://grafana.example.com/",
+			"GRAFANA_TOKEN":  "token",
+		},
+	}
+
+	testCase.Run(t)
+}


### PR DESCRIPTION
Environment variables were loaded only if a configuration file existed, breaking [one of the first usage examples in the documentation](https://grafana.github.io/grafanactl/configuration/#using-environment-variables) :'(

This PR adds a test for that issue and fixes it.