### PR TITLE
Improve API error handling

### DIFF
--- a/internal/resources/dynamic/errors.go
+++ b/internal/resources/dynamic/errors.go
@@ -1,0 +1,44 @@
+package dynamic
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// APIError is an error that wraps a Kubernetes API status.
+// It formats the error message in a more readable format
+// (since Kubernetes natively will only log the message, which could sometimes be simply "unknown").
+type APIError struct {
+	Status metav1.Status
+}
+
+// Error implements the error interface.
+// It logs the code & reason in addition to the message,
+// which could be simply "unknown" in some cases.
+func (e APIError) Error() string {
+	return fmt.Sprintf("%d %s: %s", e.Status.Code, string(e.Status.Reason), e.Status.Message)
+}
+
+// ParseStatusError parses a Kubernetes API status from an error.
+func ParseStatusError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if status, ok := err.(apierrors.APIStatus); ok || errors.As(err, &status) {
+		return APIError{status.Status()}
+	}
+
+	return APIError{
+		Status: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Reason:  metav1.StatusReasonUnknown,
+			Code:    http.StatusInternalServerError,
+			Message: err.Error(),
+		},
+	}
+}

--- a/internal/resources/dynamic/namespaced_client.go
+++ b/internal/resources/dynamic/namespaced_client.go
@@ -39,7 +39,8 @@ func NewNamespacedClient(namespace string, client dynamic.Interface) *Namespaced
 func (c *NamespacedClient) List(
 	ctx context.Context, desc resources.Descriptor, opts metav1.ListOptions,
 ) (*unstructured.UnstructuredList, error) {
-	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).List(ctx, opts)
+	res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).List(ctx, opts)
+	return res, ParseStatusError(err)
 }
 
 // GetMultiple gets multiple resources from the server.
@@ -54,7 +55,7 @@ func (c *NamespacedClient) GetMultiple(
 ) ([]unstructured.Unstructured, error) {
 	res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).List(ctx, opts)
 	if err != nil {
-		return nil, err
+		return nil, ParseStatusError(err)
 	}
 
 	filtered := make([]unstructured.Unstructured, 0, len(res.Items))
@@ -73,33 +74,38 @@ func (c *NamespacedClient) GetMultiple(
 func (c *NamespacedClient) Get(
 	ctx context.Context, desc resources.Descriptor, name string, opts metav1.GetOptions,
 ) (*unstructured.Unstructured, error) {
-	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Get(ctx, name, opts)
+	res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Get(ctx, name, opts)
+	return res, ParseStatusError(err)
 }
 
 // Create creates a resource on the server.
 func (c *NamespacedClient) Create(
 	ctx context.Context, desc resources.Descriptor, obj *unstructured.Unstructured, opts metav1.CreateOptions,
 ) (*unstructured.Unstructured, error) {
-	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Create(ctx, obj, opts)
+	res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Create(ctx, obj, opts)
+	return res, ParseStatusError(err)
 }
 
 // Update updates a resource on the server.
 func (c *NamespacedClient) Update(
 	ctx context.Context, desc resources.Descriptor, obj *unstructured.Unstructured, opts metav1.UpdateOptions,
 ) (*unstructured.Unstructured, error) {
-	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Update(ctx, obj, opts)
+	res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Update(ctx, obj, opts)
+	return res, ParseStatusError(err)
 }
 
 // Delete deletes a resource on the server.
 func (c *NamespacedClient) Delete(
 	ctx context.Context, desc resources.Descriptor, name string, opts metav1.DeleteOptions,
 ) error {
-	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Delete(ctx, name, opts)
+	err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Delete(ctx, name, opts)
+	return ParseStatusError(err)
 }
 
 // Apply applies a resource on the server.
 func (c *NamespacedClient) Apply(
 	ctx context.Context, desc resources.Descriptor, name string, obj *unstructured.Unstructured, opts metav1.ApplyOptions,
 ) (*unstructured.Unstructured, error) {
-	return c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Apply(ctx, name, obj, opts)
+	res, err := c.client.Resource(desc.GroupVersionResource()).Namespace(c.namespace).Apply(ctx, name, obj, opts)
+	return res, ParseStatusError(err)
 }


### PR DESCRIPTION
### What

This change updates the API client with better error parsing logic, which produces more detailed API errors.

### Why

Default API error logging is not verbose enough and sometimes doesn't produce enough information for debugging those errors.

e.g. when using invalid config for Grafana Cloud (using org ID instead of stack ID):

Before:
```
❯ bin/grafanactl --context=broken resources get
WARN Could not pull resources err=unknown cmd=GetAll:playlists.v0alpha1.playlist.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:folders.v1beta1.folder.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:securevalues.v1beta1.secret.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:systems.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:keepers.v1beta1.secret.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:relationdefinitions.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:relationtypes.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:resources.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:relations.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:components.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:dashboards.v1beta1.dashboard.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:entitydefinitions.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:sandbox-settings.v0alpha1.sandboxsettings.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:checks.v0alpha1.advisor.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:appo11yconfigs.v1alpha1.productactivation.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:groups.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:investigationindexes.v0alpha1.investigations.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:apis.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:checktypes.v0alpha1.advisor.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:domains.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:investigations.v0alpha1.investigations.grafana.app
WARN Could not pull resources err=unknown cmd=GetAll:users.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err=unknown cmd=GetAll:announcement-banners.v0alpha1.banners.grafana.app
```

After:
```
❯ bin/grafanactl --context=broken resources get
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:entitydefinitions.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:systems.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:folders.v1beta1.folder.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:checktypes.v0alpha1.advisor.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:relations.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:securevalues.v1beta1.secret.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:investigations.v0alpha1.investigations.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:relationdefinitions.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:playlists.v0alpha1.playlist.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:users.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:groups.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:resources.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:apis.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:components.v1alpha1.servicemodel.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:announcement-banners.v0alpha1.banners.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:sandbox-settings.v0alpha1.sandboxsettings.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:appo11yconfigs.v1alpha1.productactivation.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:relationtypes.v1alpha1.gamma.ext.grafana.com
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:investigationindexes.v0alpha1.investigations.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:keepers.v1beta1.secret.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:dashboards.v1beta1.dashboard.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:checks.v0alpha1.advisor.grafana.app
WARN Could not pull resources err="403 Forbidden: unknown" cmd=GetAll:domains.v1alpha1.servicemodel.ext.grafana.com
```