### PR TITLE
Update configuration docs with mention of stack ID

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,13 +25,18 @@ Optionally, set the following values depending on your authentication method wit
 * A [token](./reference/environment-variables/index.md#grafana_token) if using a [Grafana service account](https://grafana.com/docs/grafana/latest/administration/service-accounts/) (recommended)
 * A [username](./reference/environment-variables/index.md#grafana_user) and [password](./reference/environment-variables/index.md#grafana_password) if using basic authentication
 
+!!! warning
+
+    * When using Grafana Cloud, you should use the `GRAFANA_STACK_ID` (or `stack-id` in the configuration file) configuration variable instead of the `GRAFANA_ORG_ID`. You can find your instance ID by visiting https://grafana.com, navigating to stack details page and clicking the "Details" button under Grafana.
+
 Next, consider [creating a context](#defining-contexts) to persist this configuration.
 
 Once you have configured your authentication method, you are ready to use the Grafana CLI.
 
 !!! note
 
-    Every supported environment variable is listed in our [reference documentation](./reference/environment-variables/index.md).
+    * Every supported environment variable is listed in our [reference documentation](./reference/environment-variables/index.md).
+    * Check the [config file reference documentation](./reference/configuration/index.md) for details on all available config options.
 
 ## Defining contexts
 


### PR DESCRIPTION
### What

This commit updates the docs for configuration to state that stack ID is required for Grafana Cloud (compared to using org ID for on-prem instances).

### Why

To make sure it's clear to users how to set up their configurations when using Grafana Cloud.