### PR TITLE
Mention feature toggles in dashboards-as-code docs

### DIFF
--- a/docs/guides/dashboards-as-code.md
+++ b/docs/guides/dashboards-as-code.md
@@ -4,6 +4,14 @@ title: Dashboards as code
 
 With this workflow, you can define and manage dashboards as code, saving them to a version control system like Git. This is useful for teams that want to maintain a history of changes, collaborate on dashboard design, and ensure consistency across environments.
 
+!!! note
+    In order to use `grafanactl resources serve` functionality, you will have to enable a feature toggle in your `config.ini`:
+      ```ini
+      [feature_toggles]
+      kubernetesDashboards = true
+      ```
+    Check [the documentation](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles) to learn more about enabling feature toggles.
+
 1. Use a dashboard generation script (for example, with the [Foundation SDK](https://github.com/grafana/grafana-foundation-sdk)). You can find an example implementation in the Grafana as code [hands-on lab repository](https://github.com/grafana/dashboards-as-code-workshop/tree/main/part-one-golang-starter).
 1. Serve and preview the output of the dashboard generator locally:
    ```shell


### PR DESCRIPTION
### What

This commit updates the dashboards-as-code doc to mention the requirement for a feature toggle.

### Why

Said FT is requires for `grafanactl resources serve` to work properly.

Closes #107 