### PR TITLE
Fix API errors interface compliance

### DIFF
--- a/cmd/grafanactl/config/command_test.go
+++ b/cmd/grafanactl/config/command_test.go
@@ -288,10 +288,12 @@ current-context: prod
 	testCase.Run(t)
 }
 
-func Test_ViewCommand_withEnvironmentVariablesAndNoConfig(t *testing.T) {
+func Test_ViewCommand_withEnvironmentVariablesAndEmptyConfig(t *testing.T) {
+	configFile := testutils.CreateTempFile(t, "contexts:")
+
 	testCase := testutils.CommandTestCase{
 		Cmd:     config.Command(),
-		Command: []string{"view", "--minify", "--raw"},
+		Command: []string{"view", "--config", configFile, "--minify", "--raw"},
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandSuccess(),
 			testutils.CommandOutputEquals(`contexts:

--- a/internal/resources/dynamic/errors.go
+++ b/internal/resources/dynamic/errors.go
@@ -13,14 +13,19 @@ import (
 // It formats the error message in a more readable format
 // (since Kubernetes natively will only log the message, which could sometimes be simply "unknown").
 type APIError struct {
-	Status metav1.Status
+	status metav1.Status
 }
 
 // Error implements the error interface.
 // It logs the code & reason in addition to the message,
 // which could be simply "unknown" in some cases.
 func (e APIError) Error() string {
-	return fmt.Sprintf("%d %s: %s", e.Status.Code, string(e.Status.Reason), e.Status.Message)
+	return fmt.Sprintf("%d %s: %s", e.status.Code, string(e.status.Reason), e.status.Message)
+}
+
+// Status implements the apierrors.APIStatus interface.
+func (e APIError) Status() metav1.Status {
+	return e.status
 }
 
 // ParseStatusError parses a Kubernetes API status from an error.
@@ -34,7 +39,7 @@ func ParseStatusError(err error) error {
 	}
 
 	return APIError{
-		Status: metav1.Status{
+		status: metav1.Status{
 			Status:  metav1.StatusFailure,
 			Reason:  metav1.StatusReasonUnknown,
 			Code:    http.StatusInternalServerError,

--- a/internal/resources/dynamic/errors.go
+++ b/internal/resources/dynamic/errors.go
@@ -9,6 +9,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var _ apierrors.APIStatus = (*APIError)(nil)
+
 // APIError is an error that wraps a Kubernetes API status.
 // It formats the error message in a more readable format
 // (since Kubernetes natively will only log the message, which could sometimes be simply "unknown").


### PR DESCRIPTION
### What

This PR addresses API error interface compliance which was broken in #128. This led to the problem that API errors were not identified properly as `NotFound` or `AlreadyExists`, making `grafanactl push` not work as expected.

### Why

To make sure that `grafanactl push` can properly create objects which don't exist or overwrite existing objects.
