### PR TITLE
Fix serve header overlap of iframe

### DIFF
--- a/internal/server/embed/assets/style.css
+++ b/internal/server/embed/assets/style.css
@@ -73,7 +73,7 @@ main {
 
 iframe {
     position: absolute;
-    top: 1.9rem;
+    top: 5.2em;
     z-index: -1;
     bottom: 0;
     left: 0;
@@ -81,5 +81,5 @@ iframe {
     border: 0;
     margin: 0;
     width: 100%;
-    height: 100%;
+    height: calc(100% - 5.2em);
 }


### PR DESCRIPTION
Without the fix, the target grafana header bar is not visible:

<img width="218" height="116" alt="image" src="https://github.com/user-attachments/assets/400b7ca3-28af-40d1-8d53-8797e44267d6" />

With the fix, it shows up correctly

<img width="228" height="160" alt="image" src="https://github.com/user-attachments/assets/8e8e0c44-110a-4774-b2a7-52674739a68b" />

This also removes the extra scroll bar created by fixing the height of the iframe.