### PR TITLE
Allow /bootdata to be proxied for frontend-service

### DIFF
--- a/internal/server/handlers/dashboards-proxy.go
+++ b/internal/server/handlers/dashboards-proxy.go
@@ -78,6 +78,7 @@ func (c *DashboardProxy) StaticEndpoints() StaticProxyConfig {
 			"/api/datasources/proxy/*",
 			"/api/datasources/*",
 			"/api/plugins/*",
+			"/bootdata",
 		},
 		ProxyPost: []string{
 			"/api/datasources/proxy/*",


### PR DESCRIPTION
Fixes https://github.com/grafana/grafanactl/issues/148

When loading Grafana through the frontend-service, an additional API call to `/bootdata` is required to initialise the frontend. This API call needs to be proxied through to the instance and not just mocked because it needs to return data source configuration.

To repro locally:

1. check out grafana repo
2. install tilt.dev
3. `make frontend-service`
4. grafana is running at `localhost:3000` through the frontend-service