### PR TITLE
Fix issues when serving and saving dashboards to disk

### DIFF
--- a/internal/resources/resources.go
+++ b/internal/resources/resources.go
@@ -17,6 +17,8 @@ import (
 const (
 	// TODO: change once we have a proper manager kind for grafanactl.
 	ResourceManagerKind = utils.ManagerKindKubectl
+	// TODO: move this to grafana/grafana.
+	AnnotationSavedFromUI = "grafana.app/saved-from-ui"
 )
 
 // ResourceRef is a unique identifier for a resource.


### PR DESCRIPTION
### What

This commit fixes a few issues in the dashboards serving proxy which prevented rendering from working correctly and saving to disk not working.

### Why

So that serving dashboards now works correctly and saves the changes back to disk when the dashboard is saved in the UI.