### PR TITLE
Override namespace from context during push operations

### DIFF
--- a/cmd/grafanactl/resources/push.go
+++ b/cmd/grafanactl/resources/push.go
@@ -137,7 +137,12 @@ func pushCmd(configOpts *cmdconfig.Options) *cobra.Command {
 				return err
 			}
 
-			procs := []remote.Processor{}
+			procs := []remote.Processor{
+				// Override namespace to match the target context.
+				// This ensures resources are pushed to the current context's namespace
+				// regardless of the namespace stored in the resource files.
+				process.NewNamespaceOverrider(cfg.Namespace),
+			}
 			if !opts.OmitManagerFields {
 				procs = append(procs, &process.ManagerFieldsAppender{})
 			}

--- a/internal/resources/process/namespace.go
+++ b/internal/resources/process/namespace.go
@@ -1,0 +1,33 @@
+package process
+
+import (
+	"github.com/grafana/grafanactl/internal/resources"
+)
+
+// NamespaceOverrider is a processor that overrides the namespace of a resource
+// with a target namespace. This is useful when pushing resources to a different
+// context/org than the one they were pulled from.
+type NamespaceOverrider struct {
+	targetNamespace string
+}
+
+// NewNamespaceOverrider creates a new NamespaceOverrider that will set the
+// namespace of all processed resources to the given target namespace.
+func NewNamespaceOverrider(targetNamespace string) *NamespaceOverrider {
+	return &NamespaceOverrider{
+		targetNamespace: targetNamespace,
+	}
+}
+
+// Process overrides the namespace of the resource with the target namespace.
+// If the resource is empty, it returns immediately without error.
+func (n *NamespaceOverrider) Process(r *resources.Resource) error {
+	if r.IsEmpty() {
+		return nil
+	}
+
+	// Override the namespace in the unstructured object
+	r.Object.SetNamespace(n.targetNamespace)
+
+	return nil
+}

--- a/internal/resources/process/namespace_test.go
+++ b/internal/resources/process/namespace_test.go
@@ -1,0 +1,189 @@
+package process_test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafanactl/internal/resources"
+	"github.com/grafana/grafanactl/internal/resources/process"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestNamespaceOverrider(t *testing.T) {
+	tests := []struct {
+		name            string
+		targetNamespace string
+		input           *resources.Resource
+		want            unstructured.Unstructured
+		wantErr         bool
+	}{
+		{
+			name:            "empty resource",
+			targetNamespace: "target-namespace",
+			input:           &resources.Resource{},
+			want:            unstructured.Unstructured{},
+			wantErr:         false,
+		},
+		{
+			name:            "resource with different namespace",
+			targetNamespace: "target-namespace",
+			input: resources.MustFromObject(
+				map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "source-namespace",
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+				resources.SourceInfo{
+					Path: "some/test/path.json",
+				},
+			),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "target-namespace",
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "resource with same namespace (no-op)",
+			targetNamespace: "same-namespace",
+			input: resources.MustFromObject(
+				map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "same-namespace",
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+				resources.SourceInfo{
+					Path: "some/test/path.json",
+				},
+			),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "same-namespace",
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "resource without namespace field",
+			targetNamespace: "target-namespace",
+			input: resources.MustFromObject(
+				map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name": "example",
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+				resources.SourceInfo{
+					Path: "some/test/path.json",
+				},
+			),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "target-namespace",
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "resource with metadata fields and annotations",
+			targetNamespace: "new-namespace",
+			input: resources.MustFromObject(
+				map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "old-namespace",
+						"labels": map[string]any{
+							"app": "test",
+						},
+						"annotations": map[string]any{
+							"description": "test dashboard",
+						},
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+				resources.SourceInfo{
+					Path: "some/test/path.json",
+				},
+			),
+			want: unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name":      "example",
+						"namespace": "new-namespace",
+						"labels": map[string]any{
+							"app": "test",
+						},
+						"annotations": map[string]any{
+							"description": "test dashboard",
+						},
+					},
+					"spec": map[string]any{
+						"title": "example",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			overrider := process.NewNamespaceOverrider(test.targetNamespace)
+			err := overrider.Process(test.input)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, test.input.ToUnstructured())
+		})
+	}
+}

--- a/internal/resources/process/serverfields.go
+++ b/internal/resources/process/serverfields.go
@@ -49,7 +49,10 @@ func (m *ServerFieldsStripper) Process(r *resources.Resource) error {
 			"apiVersion": r.APIVersion(),
 			"kind":       r.Kind(),
 			"metadata": map[string]any{
-				"name":        r.Name(),
+				"name": r.Name(),
+				// Preserve the original namespace for inspection.
+				// When pushing, the NamespaceOverrider processor will override
+				// this with the target context's namespace.
 				"namespace":   r.Namespace(),
 				"annotations": annotations,
 				"labels":      labels,


### PR DESCRIPTION
### What
- Added NamespaceOverrider processor in internal/resources/process/namespace.go to override resource namespaces
- Integrated NamespaceOverrider into push command pipeline in cmd/grafanactl/resources/push.go
- Added comprehensive test suite (5 test cases) for NamespaceOverrider covering edge cases
- Added clarifying comment in serverfields.go about namespace preservation semantics

### Why
- Enables seamless cross-org/stack migrations when pushing resources to Grafana
- Resources now automatically use the namespace from the current context instead of embedded values
- Allows users to push resource definitions from one org/stack to another without manual editing
- Improves user experience for infrastructure-as-code workflows across multiple Grafana environments
- Fixes #158

Generated with [Claude Code](https://claude.com/claude-code)