### PR TITLE
Add docker-compose integration test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 /resources
 .idea
 .qodo
+
+# Integration testing artifacts
+test-dashboard.yaml
+test-*.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,228 @@ $ devbox add go@1.24
 ```
 
 Available packages can be found on the [NixOS package repository](https://search.nixos.org/packages).
+
+## Testing against a real Grafana API
+
+While unit tests are valuable for testing individual components, integration testing against a real Grafana instance is important to ensure `grafanactl` works correctly with the actual Grafana API.
+
+### Quick Start
+
+The repository includes a `docker-compose.yml` file that sets up a complete test environment with:
+
+- **Grafana 12.2** (latest stable release)
+- **MySQL 8.0** (as the backend database)
+- Pre-configured with `admin:admin` credentials
+- The `kubernetesDashboards` feature toggle enabled (required for `grafanactl`)
+
+### Starting the test environment
+
+Start the services using the Make target:
+
+```console
+$ make test-env-up
+```
+
+This will start both Grafana and MySQL, wait for them to be healthy, and display the connection information.
+
+You can also start the services manually:
+
+```console
+$ docker-compose up -d
+```
+
+Check the status of the services:
+
+```console
+$ make test-env-status
+```
+
+Or manually:
+
+```console
+$ docker-compose ps
+```
+
+You should see both `grafanactl-grafana` and `grafanactl-mysql` in a `healthy` state.
+
+Verify Grafana is accessible:
+
+```console
+$ curl -u admin:admin http://localhost:3000/api/health
+```
+
+You should receive a JSON response indicating Grafana is running.
+
+### Testing with grafanactl
+
+The repository includes a pre-configured test config file at `testdata/integration-test-config.yaml` that you can use to test `grafanactl` against the local Grafana instance.
+
+#### View the test configuration
+
+```console
+$ devbox run go run ./cmd/grafanactl --config testdata/integration-test-config.yaml config view
+```
+
+#### List available resources
+
+```console
+$ devbox run go run ./cmd/grafanactl --config testdata/integration-test-config.yaml resources list
+```
+
+#### Create a test dashboard
+
+1. Create a dashboard YAML file (e.g., `test-dashboard.yaml`):
+
+```yaml
+apiVersion: v1alpha1
+kind: Dashboard
+metadata:
+  name: test-dashboard
+spec:
+  title: Test Dashboard
+  tags: [test]
+  timezone: browser
+  schemaVersion: 36
+```
+
+2. Push it to Grafana:
+
+```console
+$ devbox run go run ./cmd/grafanactl --config testdata/integration-test-config.yaml resources push test-dashboard.yaml
+```
+
+3. Pull it back to verify:
+
+```console
+$ devbox run go run ./cmd/grafanactl --config testdata/integration-test-config.yaml resources get dashboards/test-dashboard
+```
+
+#### Testing the serve command
+
+The `serve` command allows you to develop dashboards locally with live reload:
+
+```console
+$ devbox run go run ./cmd/grafanactl --config testdata/integration-test-config.yaml resources serve test-dashboard.yaml
+```
+
+Then open your browser to the URL shown in the output (typically `http://localhost:8080`).
+
+### Stopping the test environment
+
+When you're done testing, stop the services:
+
+```console
+$ make test-env-down
+```
+
+Or manually:
+
+```console
+$ docker-compose down
+```
+
+To remove all data (including database volumes):
+
+```console
+$ make test-env-clean
+```
+
+Or manually:
+
+```console
+$ docker-compose down -v
+```
+
+### Customizing the test environment
+
+#### Modifying Grafana configuration
+
+The Grafana instance uses a custom configuration file at `testdata/grafana.ini`. You can modify this file to change Grafana's behavior. After making changes, restart the services:
+
+```console
+$ docker-compose restart grafana
+```
+
+#### Using a different Grafana version
+
+To test against a different Grafana version, modify the `image` field in `docker-compose.yml`:
+
+```yaml
+services:
+  grafana:
+    image: grafana/grafana:12.1  # or any other version
+```
+
+Then restart the services:
+
+```console
+$ docker-compose up -d --force-recreate grafana
+```
+
+#### Viewing logs
+
+To view logs from both services:
+
+```console
+$ make test-env-logs
+```
+
+To view logs from a specific service:
+
+```console
+$ docker-compose logs -f grafana
+```
+
+Or for MySQL:
+
+```console
+$ docker-compose logs -f mysql
+```
+
+### Troubleshooting
+
+#### Grafana won't start or is unhealthy
+
+Check the logs for errors:
+
+```console
+$ docker-compose logs grafana
+```
+
+Common issues:
+- MySQL not fully initialized yet - wait a few more seconds and check again
+- Port 3000 already in use - stop any other Grafana instances or change the port in `docker-compose.yml`
+
+#### Cannot connect to Grafana from grafanactl
+
+Verify Grafana is accessible:
+
+```console
+$ curl -u admin:admin http://localhost:3000/api/health
+```
+
+If this fails, check:
+- Services are running: `docker-compose ps`
+- Firewall settings are not blocking port 3000
+- Check Grafana logs: `docker-compose logs grafana`
+
+#### Database connection errors
+
+Check MySQL is healthy:
+
+```console
+$ docker-compose ps mysql
+```
+
+If MySQL is not healthy, check the logs:
+
+```console
+$ docker-compose logs mysql
+```
+
+You may need to remove the volume and recreate it:
+
+```console
+$ docker-compose down -v
+$ docker-compose up -d
+```

--- a/Makefile
+++ b/Makefile
@@ -129,3 +129,45 @@ config-reference-drift: config-reference ## Checks for drift in the generated co
 .PHONY: serve-docs
 serve-docs: check-binaries ## Serves the documentation and watches for changes.
 	$(RUN_DEVBOX) mkdocs serve -f mkdocs.yml
+
+
+##@ Integration Testing
+
+.PHONY: test-env-up
+test-env-up: ## Starts the docker-compose test environment (Grafana + MySQL).
+	@echo "Starting test environment..."
+	@docker-compose up -d
+	@echo "Waiting for services to be healthy..."
+	@for i in {1..30}; do \
+		if docker-compose ps | grep -q "healthy"; then \
+			echo "Services are healthy!"; \
+			echo ""; \
+			echo "Grafana is available at: http://localhost:3000"; \
+			echo "Credentials: admin/admin"; \
+			echo ""; \
+			echo "Test with: make test-env-status"; \
+			exit 0; \
+		fi; \
+		echo -n "."; \
+		sleep 1; \
+	done; \
+	echo ""; \
+	echo "Warning: Services may still be starting up. Check with: docker-compose ps"
+
+.PHONY: test-env-down
+test-env-down: ## Stops and removes the docker-compose test environment.
+	@echo "Stopping test environment..."
+	@docker-compose down
+
+.PHONY: test-env-clean
+test-env-clean: ## Stops the test environment and removes all volumes.
+	@echo "Stopping test environment and removing volumes..."
+	@docker-compose down -v
+
+.PHONY: test-env-status
+test-env-status: ## Shows the status of the test environment services.
+	@docker-compose ps
+
+.PHONY: test-env-logs
+test-env-logs: ## Shows logs from the test environment (Grafana and MySQL).
+	@docker-compose logs -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: '3.9'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: grafanactl-mysql
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_DATABASE: grafana
+      MYSQL_USER: grafana
+      MYSQL_PASSWORD: grafana
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --max-connections=1001
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-prootpassword"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - grafana
+
+  grafana:
+    image: grafana/grafana:12.2
+    container_name: grafanactl-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      # Database configuration
+      GF_DATABASE_TYPE: mysql
+      GF_DATABASE_HOST: mysql:3306
+      GF_DATABASE_NAME: grafana
+      GF_DATABASE_USER: grafana
+      GF_DATABASE_PASSWORD: grafana
+      # Admin credentials (default: admin/admin)
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      # Enable Kubernetes dashboards feature (required for grafanactl)
+      GF_FEATURE_TOGGLES_ENABLE: kubernetesDashboards
+      # Disable analytics
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+    volumes:
+      - ./testdata/grafana.ini:/etc/grafana/grafana.ini:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      mysql:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - grafana
+
+volumes:
+  mysql_data:
+    driver: local
+  grafana_data:
+    driver: local
+
+networks:
+  grafana:
+    driver: bridge

--- a/testdata/grafana.ini
+++ b/testdata/grafana.ini
@@ -1,0 +1,66 @@
+##################### Grafana Configuration for grafanactl Testing #####################
+#
+# This is a minimal Grafana configuration file for testing grafanactl against a local
+# Grafana instance running in Docker. Most configuration is handled via environment
+# variables in docker-compose.yml, but this file can be used for additional customization.
+#
+
+[paths]
+# Path to where grafana stores plugins
+;plugins = /var/lib/grafana/plugins
+# Path to where grafana stores temporary files
+;temp_data_lifetime = 24h
+
+[server]
+# Protocol (http, https, h2, socket)
+protocol = http
+# The http port to use
+http_port = 3000
+# The public facing domain name used to access grafana from a browser
+domain = localhost
+# Redirect to correct domain if host header does not match domain
+enforce_domain = false
+# The full public facing url
+root_url = %(protocol)s://%(domain)s:%(http_port)s/
+
+[database]
+# You can configure the database connection in docker-compose.yml via environment variables
+# or you can configure it here. Environment variables take precedence.
+# Database connection is already configured via environment variables in docker-compose.yml
+
+[security]
+# Default admin user and password (configured via environment variables in docker-compose.yml)
+# admin_user = admin
+# admin_password = admin
+
+[users]
+# Default theme (light, dark, or system)
+default_theme = dark
+# Allow users to sign up for an account
+allow_sign_up = false
+# Allow org admins to invite users
+allow_org_create = false
+
+[auth.anonymous]
+# Enable anonymous access
+enabled = false
+
+[analytics]
+# Disable reporting
+reporting_enabled = false
+check_for_updates = false
+
+[feature_toggles]
+# Enable the kubernetesDashboards feature for grafanactl
+# This is required for grafanactl's resources commands to work properly
+enable = kubernetesDashboards
+
+[log]
+# Either "console", "file", "syslog". Default is console and file
+mode = console
+# Either "debug", "info", "warn", "error", "critical", default is "info"
+level = info
+
+[log.console]
+# log line format, valid options are text, console and json
+format = console

--- a/testdata/integration-test-config.yaml
+++ b/testdata/integration-test-config.yaml
@@ -1,0 +1,26 @@
+# Integration test configuration for grafanactl
+# This config is used for testing grafanactl against a local Grafana instance
+# running via docker-compose.yml
+#
+# Usage:
+#   grafanactl --config testdata/integration-test-config.yaml config view
+
+current-context: "local"
+
+contexts:
+  local:
+    grafana:
+      # Local Grafana instance running in Docker
+      server: "http://localhost:3000"
+
+      # Basic authentication with default admin credentials
+      # Username: admin, Password: admin
+      basic-auth:
+        username: "admin"
+        password: "admin"
+
+      # For testing with insecure connections (self-signed certs, etc.)
+      # insecure-skip-tls-verify: true
+
+      # Default organization ID (Grafana on-prem uses org-id as namespace)
+      org-id: 1


### PR DESCRIPTION
## Summary

This PR adds a complete docker-compose-based integration test environment for testing grafanactl against a real Grafana API.

- **docker-compose.yml**: Sets up Grafana 12.2 and MySQL 8.0 with health checks and proper networking
- **testdata/grafana.ini**: Custom Grafana configuration with kubernetesDashboards feature enabled
- **testdata/integration-test-config.yaml**: Pre-configured grafanactl config for local testing with admin:admin credentials
- **Make targets**: Five new targets for easy environment management (test-env-up, test-env-down, test-env-clean, test-env-status, test-env-logs)
- **Documentation**: Comprehensive guide in CONTRIBUTING.md with quick start, testing examples, customization options, and troubleshooting

## Test plan

- [ ] Run `make test-env-up` to start the environment
- [ ] Verify services are healthy with `make test-env-status`
- [ ] Test grafanactl commands:
  - [ ] `devbox run go run ./cmd/grafanactl --config testdata/integration-test-config.yaml config view`
  - [ ] `devbox run go run ./cmd/grafanactl --config testdata/integration-test-config.yaml resources list`
- [ ] Verify logs are accessible with `make test-env-logs`
- [ ] Clean up with `make test-env-clean`
- [ ] Review CONTRIBUTING.md documentation for completeness and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)