### PR TITLE
Fix dry-run mode for resource delete operations

### DIFF
--- a/cmd/grafanactl/resources/delete.go
+++ b/cmd/grafanactl/resources/delete.go
@@ -125,7 +125,7 @@ func deleteCmd(configOpts *cmdconfig.Options) *cobra.Command {
 			}
 
 			// Delete!
-			deleter, err := remote.NewDeleter(ctx, cfg)
+			deleter, err := remote.NewDefaultDeleter(ctx, cfg)
 			if err != nil {
 				return err
 			}

--- a/internal/resources/remote/deleter_test.go
+++ b/internal/resources/remote/deleter_test.go
@@ -1,0 +1,180 @@
+package remote_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/grafana/grafanactl/internal/resources"
+	"github.com/grafana/grafanactl/internal/resources/remote"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestDeleter_Delete_DryRunSkipsAPICall(t *testing.T) {
+	tests := []struct {
+		name                string
+		dryRun              bool
+		expectDeleteAPICAll bool
+		expectedDeleted     int
+		expectedFailed      int
+	}{
+		{
+			name:                "dry-run enabled skips actual delete",
+			dryRun:              true,
+			expectDeleteAPICAll: false,
+			expectedDeleted:     2,
+			expectedFailed:      0,
+		},
+		{
+			name:                "dry-run disabled calls delete API",
+			dryRun:              false,
+			expectDeleteAPICAll: true,
+			expectedDeleted:     2,
+			expectedFailed:      0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			// Create test resources
+			testResources := resources.NewResources(
+				createFolderResource("folder-1", "v1"),
+				createDashboardResource("dashboard-1"),
+			)
+
+			// Mock client that tracks delete calls
+			mockClient := &mockDeleteClient{
+				deleteCalls: []string{},
+				mu:          sync.Mutex{},
+			}
+
+			// Mock registry that supports all test resources
+			mockRegistry := &mockRegistry{
+				supportedResources: []resources.Descriptor{
+					{
+						GroupVersion: schema.GroupVersion{Group: "folder.grafana.app", Version: "v1"},
+						Kind:         "Folder",
+						Singular:     "folder",
+						Plural:       "folders",
+					},
+					{
+						GroupVersion: schema.GroupVersion{Group: "dashboard.grafana.app", Version: "v1"},
+						Kind:         "Dashboard",
+						Singular:     "dashboard",
+						Plural:       "dashboards",
+					},
+				},
+			}
+
+			deleter := remote.NewDeleter(mockClient, mockRegistry)
+
+			// Delete resources
+			summary, err := deleter.Delete(t.Context(), remote.DeleteRequest{
+				Resources:      testResources,
+				MaxConcurrency: 2,
+				DryRun:         tt.dryRun,
+			})
+
+			req.NoError(err)
+			req.Equal(tt.expectedDeleted, summary.DeletedCount)
+			req.Equal(tt.expectedFailed, summary.FailedCount)
+
+			// Verify delete API calls
+			if tt.expectDeleteAPICAll {
+				req.Len(mockClient.deleteCalls, 2, "Should have made 2 delete API calls")
+			} else {
+				req.Empty(mockClient.deleteCalls, "Should not have made any delete API calls in dry-run mode")
+			}
+		})
+	}
+}
+
+func TestDeleter_Delete_EmptyResources(t *testing.T) {
+	req := require.New(t)
+
+	testResources := resources.NewResources()
+
+	mockClient := &mockDeleteClient{
+		deleteCalls: []string{},
+		mu:          sync.Mutex{},
+	}
+
+	mockRegistry := &mockRegistry{
+		supportedResources: []resources.Descriptor{},
+	}
+
+	deleter := remote.NewDeleter(mockClient, mockRegistry)
+
+	summary, err := deleter.Delete(t.Context(), remote.DeleteRequest{
+		Resources:      testResources,
+		MaxConcurrency: 2,
+		DryRun:         false,
+	})
+
+	req.NoError(err)
+	req.Equal(0, summary.DeletedCount)
+	req.Equal(0, summary.FailedCount)
+	req.Empty(mockClient.deleteCalls)
+}
+
+func TestDeleter_Delete_UnsupportedResource(t *testing.T) {
+	req := require.New(t)
+
+	// Create a resource with an unsupported GVK
+	testResources := resources.NewResources(
+		createFolderResource("folder-1", "v1"),
+	)
+
+	mockClient := &mockDeleteClient{
+		deleteCalls: []string{},
+		mu:          sync.Mutex{},
+	}
+
+	// Registry that doesn't support folders
+	mockRegistry := &mockRegistry{
+		supportedResources: []resources.Descriptor{},
+	}
+
+	deleter := remote.NewDeleter(mockClient, mockRegistry)
+
+	summary, err := deleter.Delete(t.Context(), remote.DeleteRequest{
+		Resources:      testResources,
+		MaxConcurrency: 2,
+		DryRun:         false,
+		StopOnError:    false, // Don't stop on error
+	})
+
+	req.NoError(err)
+	req.Equal(0, summary.DeletedCount, "Should not delete unsupported resources")
+	req.Equal(0, summary.FailedCount, "Should skip unsupported resources, not fail")
+	req.Empty(mockClient.deleteCalls)
+}
+
+// Mock implementations
+
+type mockDeleteClient struct {
+	deleteCalls []string
+	mu          sync.Mutex
+}
+
+func (m *mockDeleteClient) Delete(
+	_ context.Context, desc resources.Descriptor, name string, _ metav1.DeleteOptions,
+) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.deleteCalls = append(m.deleteCalls, desc.Kind+"/"+name)
+	return nil
+}
+
+type mockRegistry struct {
+	supportedResources []resources.Descriptor
+}
+
+func (m *mockRegistry) SupportedResources() resources.Descriptors {
+	return m.supportedResources
+}

--- a/internal/resources/remote/pusher.go
+++ b/internal/resources/remote/pusher.go
@@ -17,11 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// PushRegistry is a registry of resources that can be pushed to Grafana.
-type PushRegistry interface {
-	SupportedResources() resources.Descriptors
-}
-
 // PushClient is a client that can push resources to Grafana.
 type PushClient interface {
 	Create(
@@ -40,7 +35,7 @@ type PushClient interface {
 // Pusher takes care of pushing resources to Grafana API.
 type Pusher struct {
 	client   PushClient
-	registry PushRegistry
+	registry Registry
 }
 
 // NewDefaultPusher creates a new Pusher.
@@ -60,7 +55,7 @@ func NewDefaultPusher(ctx context.Context, cfg config.NamespacedRESTConfig) (*Pu
 }
 
 // NewPusher creates a new Pusher.
-func NewPusher(client PushClient, registry PushRegistry) *Pusher {
+func NewPusher(client PushClient, registry Registry) *Pusher {
 	return &Pusher{
 		client:   client,
 		registry: registry,

--- a/internal/resources/remote/remote.go
+++ b/internal/resources/remote/remote.go
@@ -2,6 +2,11 @@ package remote
 
 import "github.com/grafana/grafanactl/internal/resources"
 
+// Registry is a registry of resources supported by the Grafana API.
+type Registry interface {
+	SupportedResources() resources.Descriptors
+}
+
 // Processor can be used to modify a resource in-place,
 // before it is written or after it is read from local sources.
 //


### PR DESCRIPTION
### What
- Implement client-side dry-run by skipping API calls when --dry-run is enabled
- Add DeleteClient interface for dependency injection in deleter
- Create shared Registry interface in remote.go to eliminate code duplication
- Add comprehensive test coverage for dry-run behavior in deleter_test.go
- Update delete command to use NewDefaultDeleter factory

### Why
The k8s.io/client-go dynamic client sends DeleteOptions in the HTTP body instead of as query parameters, which causes the Kubernetes API server to ignore the DryRun field. This resulted in resources (especially folders) being actually deleted even when --dry-run was set. By implementing client-side dry-run verification, we ensure no resources are deleted when the flag is enabled.

Fixes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)