### PR TITLE
Remove unsupported Renovate dependency group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -65,16 +65,6 @@
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Group Devbox dependencies (development environment tools)",
-      "matchManagers": [
-        "devbox"
-      ],
-      "groupName": "Devbox dependencies",
-      "groupSlug": "devbox-deps",
-      "semanticCommitType": "build",
-      "semanticCommitScope": "devbox"
-    },
-    {
       "description": "Group all GitHub Actions together - maintains digest pinning for security while reducing PR noise",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
### What

Remove Devbox from Renovate config.

### Why

Renovate does not support Devbox.