### PR TITLE
Fix push failing with missing resourceVersion on update

### DIFF
--- a/internal/resources/remote/pusher.go
+++ b/internal/resources/remote/pusher.go
@@ -275,15 +275,13 @@ func (p *Pusher) upsertResource(
 	}
 
 	// Check if the resource already exists.
-	_, err := p.client.Get(ctx, desc, name, metav1.GetOptions{})
+	existing, err := p.client.Get(ctx, desc, name, metav1.GetOptions{})
 	if err == nil {
 		obj := src.ToUnstructured()
 
-		// Otherwise, update the resource.
-		// TODO: double-check if we need to do some resource version shenanigans here.
-		// (most likely yes)
-		// Something like – take existing resource, replace the annotations, labels, spec, etc.
-		// and then push it back.
+		// Copy the resourceVersion from the existing resource so the API accepts the update.
+		obj.SetResourceVersion(existing.GetResourceVersion())
+
 		if _, err := p.client.Update(ctx, desc, &obj, metav1.UpdateOptions{
 			DryRun: dryRunOpts,
 		}); err != nil {


### PR DESCRIPTION
### What

Copy `resourceVersion` from the existing resource (fetched via Get) onto the local resource object before calling Update. Enhanced the push test mock to support returning existing resources and added table-driven tests covering the update path.

### Why

The Kubernetes API requires `resourceVersion` to be set on update operations for optimistic concurrency control. Previously, the `Get` result was discarded, causing a 422 error when pushing updates for existing resources.

Fixes #160

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
