### PR TITLE
docs: deprecate grafanactl in favour of gcx

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > **`grafanactl` is being deprecated.** We're bringing all our learnings and experience into the new, improved CLI tool [gcx](https://github.com/grafana/gcx).
 >
-> To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`.
+> To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 
 Grafana CLI (_grafanactl_) is a command-line tool designed to simplify interaction with Grafana instances.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Grafana CLI
 
-> [!NOTE]
-> **Grafana CLI only supports *Grafana 12 and above*, older Grafana versions are not supported!**
+> [!WARNING]
+> **`grafanactl` is being deprecated.** We're bringing all our learnings and experience into the new, improved CLI tool [gcx](https://github.com/grafana/gcx).
+>
+> To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`.
 
 Grafana CLI (_grafanactl_) is a command-line tool designed to simplify interaction with Grafana instances.
 


### PR DESCRIPTION
## Summary

- Replaces the Grafana 12 note at the top of the README with a deprecation warning
- Points users to [gcx](https://github.com/grafana/gcx) as the new CLI
- Includes migration instructions (search-and-replace `grafanactl` with `gcx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)