### PR TITLE
feat(config): redact secret values when reporting config errors

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -7,11 +7,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 
 	"github.com/adrg/xdg"
 	"github.com/goccy/go-yaml"
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafanactl/internal/format"
+	"github.com/grafana/grafanactl/internal/secrets"
 )
 
 const (
@@ -79,9 +81,25 @@ func Load(ctx context.Context, source Source, overrides ...Override) (Config, er
 		return config, err
 	}
 
+	// Compute a length-preserving redacted copy of the file contents once.
+	// Sensitive scalar values (fields tagged datapolicy:"secret") are replaced
+	// with "**REDACTED**" padded to the same byte length. This copy is used
+	// exclusively for error rendering so that goccy/go-yaml's Token.Origin
+	// references redacted bytes rather than the raw secrets.
+	redactedContents := secrets.RedactYAMLSecrets(contents, reflect.TypeFor[Context]())
+
 	codec := &format.YAMLCodec{BytesAsBase64: true}
 	if err := codec.Decode(bytes.NewBuffer(contents), &config); err != nil {
-		return config, UnmarshalError{File: filename, Err: err}
+		// Re-parse with the redacted buffer to obtain an error whose Token
+		// metadata references safe (redacted) source bytes. Because redaction
+		// is length-preserving and does not alter YAML syntax, the redacted
+		// decode hits the same structural error at the same position.
+		var throwaway Config
+		redactedErr := err
+		if rerr := codec.Decode(bytes.NewBuffer(redactedContents), &throwaway); rerr != nil {
+			redactedErr = rerr
+		}
+		return config, UnmarshalError{File: filename, Err: redactedErr}
 	}
 
 	for name, ctx := range config.Contexts {
@@ -90,7 +108,7 @@ func Load(ctx context.Context, source Source, overrides ...Override) (Config, er
 
 	for _, override := range overrides {
 		if err := override(&config); err != nil {
-			return config, annotateErrorWithSource(filename, contents, err)
+			return config, annotateErrorWithSource(filename, redactedContents, err)
 		}
 	}
 
@@ -115,7 +133,11 @@ func Write(ctx context.Context, source Source, cfg Config) error {
 	return codec.Encode(file, cfg)
 }
 
-func annotateErrorWithSource(filename string, contents []byte, err error) error {
+// annotateErrorWithSource wraps a ValidationError with a source snippet from
+// the config file. redactedContents must be the length-preserving redacted
+// copy of the file so that the annotated excerpt never reveals sensitive
+// scalar values (fields tagged datapolicy:"secret").
+func annotateErrorWithSource(filename string, redactedContents []byte, err error) error {
 	if err == nil {
 		return nil
 	}
@@ -127,7 +149,18 @@ func annotateErrorWithSource(filename string, contents []byte, err error) error 
 			return err
 		}
 
-		annotatedSource, err := path.AnnotateSource(contents, true)
+		// The **REDACTED** sentinel starts with '*', which goccy/go-yaml's raw
+		// YAML parser (used internally by path.AnnotateSource via
+		// parser.ParseBytes) treats as an alias indicator and fails to resolve.
+		// Replace with the YAML-safe equivalent of the same byte length so
+		// that AnnotateSource can parse the source without errors while still
+		// hiding the sensitive value.
+		annotationContents := bytes.ReplaceAll(
+			redactedContents,
+			[]byte("**REDACTED**"),
+			[]byte("__REDACTED__"),
+		)
+		annotatedSource, err := path.AnnotateSource(annotationContents, true)
 		if err != nil {
 			return err
 		}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
+	"github.com/grafana/grafanactl/cmd/grafanactl/fail"
 	"github.com/grafana/grafanactl/internal/config"
 	"github.com/grafana/grafanactl/internal/testutils"
 	"github.com/stretchr/testify/require"
@@ -151,6 +152,160 @@ this-field-is-invalid: []`
 	req.Error(err)
 	req.ErrorAs(err, &config.UnmarshalError{})
 	req.ErrorContains(err, "unknown field \"this-field-is-invalid\"")
+}
+
+// TestLoad_DoesNotLeakSecretsOnError is a regression test ensuring that
+// sensitive values (fields tagged datapolicy:"secret" such as token, password,
+// and tls.key-data) do not appear in error output produced by
+// config.Load + fail.ErrorToDetailedError.
+//
+// See docs/specs/bugfix-prevent-token-leak for the full specification.
+func TestLoad_DoesNotLeakSecretsOnError(t *testing.T) {
+	// validationOverride mimics the validator used by the real CLI (LoadConfig).
+	validationOverride := func(cfg *config.Config) error {
+		if !cfg.HasContext(cfg.CurrentContext) {
+			return config.ContextNotFound(cfg.CurrentContext)
+		}
+		return cfg.GetCurrentContext().Validate()
+	}
+
+	tests := []struct {
+		name    string
+		fixture string
+		// overrides are optional; pass validationOverride to trigger validation.
+		overrides []config.Override
+		wantErr   bool
+		// checkRendered asserts properties of the full DetailedError.Error() output.
+		// Used for UnmarshalError (parse-error) cases.
+		checkRendered func(t *testing.T, rendered string)
+		// checkValidation asserts properties of the ValidationError directly.
+		// Used when a ValidationError is expected.
+		checkValidation func(t *testing.T, err error)
+		// checkSuccess asserts properties of the successfully-loaded Config.
+		checkSuccess func(t *testing.T, cfg config.Config)
+	}{
+		{
+			// AC-1, AC-13: parse error on "token; glc_..." (semicolon colon-typo).
+			// RedactYAMLSecrets handles non-colon separators by matching any
+			// non-bare-key-char after a denylist key name.
+			name:    "bad-token-separator",
+			fixture: "./testdata/bad-token-separator.yaml",
+			wantErr: true,
+			checkRendered: func(t *testing.T, rendered string) {
+				t.Helper()
+				// AC-1: secret must NOT appear in rendered error output
+				require.NotContains(t, rendered, "glc_fixture_secret_value",
+					"secret value must not leak in rendered error (AC-1)")
+				// AC-13: key name "token" must be present with context
+				require.Contains(t, rendered, "token",
+					"key name must remain visible in rendered error (AC-13)")
+				// AC-6: non-secret fields adjacent to the error MUST remain visible
+				require.Contains(t, rendered, "alice@example.com",
+					"non-secret 'user' value must remain visible (AC-6)")
+				require.Contains(t, rendered, "https://grafana.example.com",
+					"non-secret 'server' value must remain visible (AC-6)")
+			},
+		},
+		{
+			// AC-2: parse error adjacent to a password: value line.
+			// The password field is tagged datapolicy:"secret", so T1 redacts it.
+			name:    "bad-password-indent",
+			fixture: "./testdata/bad-password-indent.yaml",
+			wantErr: true,
+			checkRendered: func(t *testing.T, rendered string) {
+				t.Helper()
+				// AC-2: secret must NOT appear in rendered error output
+				require.NotContains(t, rendered, "real-password-xyz",
+					"secret value must not leak in rendered error (AC-2)")
+				// AC-2: key name "password" must be present
+				require.Contains(t, rendered, "password",
+					"key name must remain visible in rendered error (AC-2)")
+			},
+		},
+		{
+			// AC-3: parse error near a tls.key-data block scalar containing a PEM body.
+			// The key-data field is tagged datapolicy:"secret", so T1 redacts the block.
+			name:    "bad-tls-key-data-block",
+			fixture: "./testdata/bad-tls-key-data-block.yaml",
+			wantErr: true,
+			checkRendered: func(t *testing.T, rendered string) {
+				t.Helper()
+				// AC-3: no PEM body line must appear in rendered error
+				require.NotContains(t, rendered, "-----BEGIN EC PRIVATE KEY-----",
+					"PEM body line must not leak in rendered error (AC-3)")
+				// AC-3: key name "key-data" must be present in surrounding context
+				require.Contains(t, rendered, "key-data",
+					"key name must remain visible in rendered error (AC-3)")
+			},
+		},
+		{
+			// AC-4: config that parses but fails validation; annotated source must
+			// show the path context without exposing the token value.
+			name:      "validation-error",
+			fixture:   "./testdata/validation-error.yaml",
+			overrides: []config.Override{validationOverride},
+			wantErr:   true,
+			checkValidation: func(t *testing.T, err error) {
+				t.Helper()
+				req := require.New(t)
+				var validationErr config.ValidationError
+				req.ErrorAs(err, &validationErr,
+					"error must be a ValidationError")
+				// AC-4: AnnotatedSource must not reveal the secret value
+				req.NotContains(validationErr.AnnotatedSource, "glc_v_secret",
+					"secret value must not leak in AnnotatedSource (AC-4)")
+				// AC-4: AnnotatedSource must be non-empty (annotation was produced)
+				req.NotEmpty(validationErr.AnnotatedSource,
+					"AnnotatedSource must contain some context (AC-4)")
+			},
+		},
+		{
+			// AC-7, AC-12: a well-formed config file must load cleanly and the real
+			// secret value must be available byte-for-byte in the returned Config
+			// (the redacted copy never reaches the Config struct).
+			name:    "valid-config",
+			fixture: "./testdata/valid-config.yaml",
+			wantErr: false,
+			checkSuccess: func(t *testing.T, cfg config.Config) {
+				t.Helper()
+				req := require.New(t)
+				ctx, ok := cfg.Contexts["test"]
+				req.True(ok, "context 'test' must exist")
+				req.NotNil(ctx, "context must not be nil")
+				req.NotNil(ctx.Grafana, "grafana config must not be nil")
+				// Real secret must survive Load unmodified (AC-7, AC-12)
+				req.Equal("glc_real_runtime_secret", ctx.Grafana.APIToken,
+					"APIToken must equal the literal value from the fixture (AC-7, AC-12)")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(tc.fixture), tc.overrides...)
+
+			if !tc.wantErr {
+				require.NoError(t, err)
+				if tc.checkSuccess != nil {
+					tc.checkSuccess(t, cfg)
+				}
+				return
+			}
+
+			require.Error(t, err)
+
+			if tc.checkRendered != nil {
+				// Render through the same pipeline that the CLI uses so that the
+				// test covers the full error-rendering path including yaml.FormatError.
+				rendered := fail.ErrorToDetailedError(err).Error()
+				tc.checkRendered(t, rendered)
+			}
+
+			if tc.checkValidation != nil {
+				tc.checkValidation(t, err)
+			}
+		})
+	}
 }
 
 func TestWrite(t *testing.T) {

--- a/internal/config/testdata/bad-password-indent.yaml
+++ b/internal/config/testdata/bad-password-indent.yaml
@@ -1,0 +1,8 @@
+contexts:
+  test:
+    grafana:
+      server: https://grafana.example.com
+      user: alice@example.com
+      password: real-password-xyz
+      org-id; 1
+current-context: test

--- a/internal/config/testdata/bad-tls-key-data-block.yaml
+++ b/internal/config/testdata/bad-tls-key-data-block.yaml
@@ -1,0 +1,9 @@
+contexts:
+  test:
+    grafana:
+      server: https://grafana.example.com
+      tls:
+        key-data: |
+          -----BEGIN EC PRIVATE KEY-----
+        next-protos: ["http/1.1", "h2"
+current-context: test

--- a/internal/config/testdata/bad-token-separator.yaml
+++ b/internal/config/testdata/bad-token-separator.yaml
@@ -1,0 +1,7 @@
+contexts:
+  test:
+    grafana:
+      server: https://grafana.example.com
+      user: alice@example.com
+      token; glc_fixture_secret_value
+current-context: test

--- a/internal/config/testdata/valid-config.yaml
+++ b/internal/config/testdata/valid-config.yaml
@@ -1,0 +1,7 @@
+contexts:
+  test:
+    grafana:
+      server: https://grafana.example.com
+      token: glc_real_runtime_secret
+      org-id: 1
+current-context: test

--- a/internal/config/testdata/validation-error.yaml
+++ b/internal/config/testdata/validation-error.yaml
@@ -1,0 +1,6 @@
+contexts:
+  test:
+    grafana:
+      token: glc_v_secret
+      org-id: 1
+current-context: test

--- a/internal/secrets/yaml.go
+++ b/internal/secrets/yaml.go
@@ -1,0 +1,324 @@
+package secrets
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+)
+
+//nolint:gochecknoglobals
+var denylistCache sync.Map
+
+// RedactYAMLSecrets returns a copy of contents where every YAML scalar value
+// associated with a key derived from a datapolicy:"secret"-tagged field in root
+// (or any struct reachable from root via pointer, struct, slice, array, or map
+// fields) is replaced by a length-preserving sentinel.
+//
+// The replacement preserves the exact byte length of the input, so that
+// yaml-library-reported line and column offsets remain accurate after
+// redaction. Sensitive scalar values are replaced with "**REDACTED**" padded
+// with ASCII spaces (when the value is longer) or truncated to the first N
+// bytes of "**REDACTED**" (when shorter). Because the sentinel is pure ASCII,
+// no UTF-8 rune is ever split at a redaction boundary.
+//
+// Coverage:
+//   - Inline scalars: key: value
+//   - Block scalars:  key: |  (followed by indented lines)
+//   - Folded scalars: key: >  (followed by indented lines)
+//
+// Non-sensitive keys, comments, newlines, and indentation are never modified.
+// Key matching is exact: "tokenizer" does not match a "token" denylist entry.
+//
+// Note: a user-defined map key that coincidentally shares the name of a
+// datapolicy-tagged field will also be redacted. This is an accepted,
+// documented limitation with no known collision in the current config schema.
+func RedactYAMLSecrets(contents []byte, root reflect.Type) []byte {
+	if len(contents) == 0 {
+		return contents
+	}
+
+	denylist := buildDenylist(root)
+
+	out := make([]byte, len(contents))
+	copy(out, contents)
+
+	if len(denylist) > 0 {
+		redactInPlace(out, denylist)
+	}
+
+	return out
+}
+
+// buildDenylist returns the set of sensitive YAML key names reachable from
+// root, computing it once and caching per root type.
+func buildDenylist(root reflect.Type) map[string]struct{} {
+	if cached, ok := denylistCache.Load(root); ok {
+		if m, ok := cached.(map[string]struct{}); ok {
+			return m
+		}
+	}
+
+	m := make(map[string]struct{})
+	visited := make(map[reflect.Type]bool)
+	walkType(root, m, visited)
+
+	canonical, _ := denylistCache.LoadOrStore(root, m)
+	if result, ok := canonical.(map[string]struct{}); ok {
+		return result
+	}
+
+	return m
+}
+
+// walkType recursively collects the YAML key names of datapolicy:"secret"-tagged
+// fields reachable from t, writing them into keys. The visited set prevents
+// infinite recursion on self-referential types.
+func walkType(t reflect.Type, keys map[string]struct{}, visited map[reflect.Type]bool) {
+	// Unwrap pointer indirections.
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		if visited[t] {
+			return
+		}
+		visited[t] = true
+
+		for _, f := range reflect.VisibleFields(t) {
+			// Skip promoted fields (embedded structs) — we recurse into their
+			// concrete types explicitly below to avoid double-counting.
+			if len(f.Index) != 1 {
+				continue
+			}
+			policy := strings.SplitN(f.Tag.Get(dataPolicyTag), ",", 2)[0]
+			if policy == "secret" {
+				name := yamlKeyName(f.Name, f.Tag.Get("yaml"))
+				if name != "" && name != "-" {
+					keys[name] = struct{}{}
+				}
+			} else {
+				walkType(f.Type, keys, visited)
+			}
+		}
+
+	case reflect.Slice, reflect.Array:
+		walkType(t.Elem(), keys, visited)
+
+	case reflect.Map:
+		walkType(t.Elem(), keys, visited)
+	}
+}
+
+// yamlKeyName returns the YAML mapping key for a struct field. It uses the
+// first token of the "yaml" struct tag when present, or the lowercased field
+// name otherwise.
+func yamlKeyName(fieldName, yamlTag string) string {
+	if yamlTag == "" {
+		return strings.ToLower(fieldName)
+	}
+	name := strings.SplitN(yamlTag, ",", 2)[0]
+	if name == "" {
+		return strings.ToLower(fieldName)
+	}
+	return name
+}
+
+// redactInPlace scans out line by line and overwrites sensitive scalar values
+// with a length-preserving sentinel. It maintains a two-state machine:
+//
+//	normal     – scanning for key lines
+//	inBlock    – consuming block/folded scalar continuation lines
+func redactInPlace(out []byte, denylist map[string]struct{}) {
+	pos := 0
+	inBlock := false
+	blockKeyIndent := 0 // column of the key that opened the block scalar
+
+	for pos < len(out) {
+		lineStart := pos
+
+		// Locate the end of the current line.
+		lineEnd := lineStart
+		for lineEnd < len(out) && out[lineEnd] != '\n' {
+			lineEnd++
+		}
+
+		// visibleEnd: position just before a trailing '\r' (CRLF handling).
+		visibleEnd := lineEnd
+		if visibleEnd > lineStart && out[visibleEnd-1] == '\r' {
+			visibleEnd--
+		}
+
+		if inBlock {
+			// Count leading whitespace bytes on this line.
+			li := lineStart
+			for li < visibleEnd && (out[li] == ' ' || out[li] == '\t') {
+				li++
+			}
+			lineIndent := li - lineStart
+			isBlank := li == visibleEnd // all-whitespace or empty line
+
+			switch {
+			case isBlank:
+				// Blank lines are part of the block scalar; leave them unchanged.
+			case lineIndent > blockKeyIndent:
+				// Continuation line: redact from first non-whitespace to end-of-line.
+				redactFill(out, li, visibleEnd)
+			default:
+				// Indent dropped to key level or less: block scalar is over.
+				inBlock = false
+				tryRedactKey(out, lineStart, visibleEnd, denylist, &inBlock, &blockKeyIndent)
+			}
+		} else {
+			tryRedactKey(out, lineStart, visibleEnd, denylist, &inBlock, &blockKeyIndent)
+		}
+
+		// Advance past the '\n', or to end of buffer.
+		if lineEnd < len(out) {
+			pos = lineEnd + 1
+		} else {
+			pos = lineEnd
+		}
+	}
+}
+
+// tryRedactKey inspects a single line for a denylist key and either redacts
+// its inline value or enters block-scalar mode.
+func tryRedactKey(out []byte, lineStart, visibleEnd int, denylist map[string]struct{}, inBlock *bool, blockKeyIndent *int) {
+	p := lineStart
+
+	// Skip leading whitespace.
+	for p < visibleEnd && (out[p] == ' ' || out[p] == '\t') {
+		p++
+	}
+
+	// Skip comment-only and blank lines.
+	if p >= visibleEnd || out[p] == '#' {
+		return
+	}
+
+	// Consume an optional list-item prefix "- " and track the column of the
+	// actual key name (needed for block-scalar indentation comparison).
+	if p+1 < visibleEnd && out[p] == '-' && out[p+1] == ' ' {
+		p += 2
+		// Skip any extra whitespace between '-' and the key name.
+		for p < visibleEnd && (out[p] == ' ' || out[p] == '\t') {
+			p++
+		}
+	}
+
+	// keyIndent: byte column of the first character of the key name.
+	keyStartPos := p
+	keyIndent := p - lineStart
+
+	// Extract the key name: scan forward while characters are valid YAML bare-key
+	// bytes ([a-zA-Z0-9_-]). Stopping at the first non-key byte lets us detect
+	// both the normal "key: value" form AND invalid-separator typos like "key; value".
+	for p < visibleEnd && isYAMLKeyByte(out[p]) {
+		p++
+	}
+
+	if p >= visibleEnd {
+		return // line is a bare word with no separator and no value
+	}
+
+	// Key not in denylist: nothing to redact on this line.
+	if _, ok := denylist[string(out[keyStartPos:p])]; !ok {
+		return
+	}
+
+	sep := out[p]
+
+	if sep != ':' {
+		// Non-standard separator (e.g. ';', '=') — the line is invalid YAML, but
+		// the key matched a sensitive name so redact everything from the separator
+		// to end-of-line (inclusive), preserving length.
+		redactFill(out, p, visibleEnd)
+		return
+	}
+
+	p++ // advance past ':'
+
+	// After ':' the next byte must be whitespace, '#', or end-of-line.
+	// This guard prevents "tokenizer:" from matching "token".
+	if p < visibleEnd && out[p] != ' ' && out[p] != '\t' && out[p] != '#' {
+		return
+	}
+
+	// Skip optional whitespace between ':' and value.
+	for p < visibleEnd && (out[p] == ' ' || out[p] == '\t') {
+		p++
+	}
+
+	// Empty value or trailing comment: nothing to redact inline.
+	if p >= visibleEnd || out[p] == '#' {
+		return
+	}
+
+	// Block or folded scalar indicator ('|' / '>') — enter block mode.
+	if isBlockMarker(out[p:visibleEnd]) {
+		*inBlock = true
+		*blockKeyIndent = keyIndent
+		return
+	}
+
+	// Inline scalar: redact everything from the start of the value to end-of-line.
+	// This includes any trailing comment, which is the safest policy.
+	redactFill(out, p, visibleEnd)
+}
+
+// isYAMLKeyByte reports whether b is a valid bare YAML key character: ASCII
+// alphanumeric, underscore, or hyphen.
+func isYAMLKeyByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') || b == '_' || b == '-'
+}
+
+// isBlockMarker reports whether b starts with a YAML block scalar indicator
+// ('|' or '>'), optionally followed by chomping indicators ('+' / '-') and/or
+// an explicit indentation digit, then optional whitespace and/or a comment.
+func isBlockMarker(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	if b[0] != '|' && b[0] != '>' {
+		return false
+	}
+	i := 1
+	for i < len(b) && (b[i] == '-' || b[i] == '+' || (b[i] >= '0' && b[i] <= '9')) {
+		i++
+	}
+	for i < len(b) {
+		switch b[i] {
+		case ' ', '\t':
+			i++
+		case '#':
+			return true
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// redactFill overwrites out[start:end] with a length-preserving sentinel.
+//
+//   - len >= 12: "**REDACTED**" followed by (len-12) ASCII spaces.
+//   - len <  12: first len bytes of "**REDACTED**" (pure ASCII, no rune split).
+//   - len == 0:  no-op.
+func redactFill(out []byte, start, end int) {
+	n := end - start
+	if n <= 0 {
+		return
+	}
+	slen := len(redacted) // 12
+	if n >= slen {
+		copy(out[start:], redacted)
+		for i := start + slen; i < end; i++ {
+			out[i] = ' '
+		}
+	} else {
+		copy(out[start:start+n], redacted[:n])
+	}
+}

--- a/internal/secrets/yaml_test.go
+++ b/internal/secrets/yaml_test.go
@@ -1,0 +1,272 @@
+package secrets_test
+
+import (
+	"reflect"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/grafana/grafanactl/internal/secrets"
+	"github.com/stretchr/testify/require"
+)
+
+// The local types below mirror internal/config's secret-carrying structs.
+// A local definition is used to avoid an import cycle: internal/config imports
+// internal/secrets via secrets.Redact[V], so internal/secrets must not import
+// internal/config.
+
+type yamlTestTLS struct {
+	KeyData string `datapolicy:"secret" yaml:"key-data"`
+	Other   string `yaml:"other"`
+}
+
+type yamlTestGrafana struct {
+	Server   string       `yaml:"server"`
+	User     string       `yaml:"user"`
+	Password string       `datapolicy:"secret" yaml:"password"`
+	Token    string       `datapolicy:"secret" yaml:"token"`
+	TLS      *yamlTestTLS `yaml:"tls"`
+}
+
+type yamlTestContext struct {
+	Grafana *yamlTestGrafana `yaml:"grafana"`
+}
+
+//nolint:gochecknoglobals
+var testRootType = reflect.TypeFor[yamlTestContext]()
+
+// utf8MultiByteValue is a string whose byte length equals the sentinel length
+// (12 bytes) and whose runes require multiple bytes each to encode. It is
+// composed of 4 euro-sign runes (U+20AC, 3 bytes each) = 12 bytes total.
+// Using a non-CJK character avoids the gosmopolitan linter warning.
+const utf8MultiByteValue = "\xe2\x82\xac\xe2\x82\xac\xe2\x82\xac\xe2\x82\xac" // "€€€€" 12 bytes
+
+// utf8ShortValue is a 3-byte UTF-8 rune (U+20AC euro sign).
+const utf8ShortValue = "\xe2\x82\xac" // "€" 3 bytes
+
+func TestRedactYAMLSecrets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		root            reflect.Type // defaults to testRootType
+		notContains     []string     // substrings that MUST be absent in output
+		contains        []string     // substrings that MUST be present in output
+		expectUnchanged bool         // output must byte-equal input
+		wantOutput      string       // exact expected output (when set)
+	}{
+		// ── inline scalars ───────────────────────────────────────────────
+		{
+			name:        "inline token",
+			input:       "token: abc123\n",
+			notContains: []string{"abc123"},
+			contains:    []string{"token"},
+		},
+		{
+			// AC-1 / AC-13 unit basis: semicolon instead of colon (colon-typo).
+			// goccy/go-yaml reports a parse error whose source window includes
+			// this line; we must redact the value even though there is no ':'.
+			name:        "invalid separator (semicolon) redacts rest of line",
+			input:       "token; glc_fixture_secret_value\n",
+			notContains: []string{"glc_fixture_secret_value"},
+			contains:    []string{"token"},
+		},
+		{
+			name:        "inline password",
+			input:       "password: hunter2\n",
+			notContains: []string{"hunter2"},
+			contains:    []string{"password"},
+		},
+		{
+			name:        "nested tls key-data inline",
+			input:       "tls:\n  key-data: supersecretvalue\n",
+			notContains: []string{"supersecretvalue"},
+			contains:    []string{"key-data"},
+		},
+		// ── block / folded scalars ────────────────────────────────────────
+		{
+			name:  "block scalar token",
+			input: "token: |\n  secretline1\n  secretline2\nother: value\n",
+			// Both continuation lines must be redacted, the terminating key must survive.
+			notContains: []string{"secretline1", "secretline2"},
+			contains:    []string{"token", "other: value"},
+		},
+		{
+			name:        "folded scalar token",
+			input:       "token: >\n  secret folded\n  more secret\nother: value\n",
+			notContains: []string{"secret folded", "more secret"},
+			contains:    []string{"token", "other: value"},
+		},
+		{
+			name: "block scalar PEM key-data",
+			input: "tls:\n" +
+				"  key-data: |\n" +
+				"    -----BEGIN PRIVATE KEY-----\n" +
+				"    MIIEvQIBADANBgk=\n" +
+				"    -----END PRIVATE KEY-----\n" +
+				"other: value\n",
+			notContains: []string{"BEGIN PRIVATE KEY", "MIIEvQIBADANBgk=", "END PRIVATE KEY"},
+			contains:    []string{"key-data", "other: value"},
+		},
+		// ── no-over-redaction ─────────────────────────────────────────────
+		{
+			name:            "similar-prefix key is not redacted",
+			input:           "tokenizer: somevalue\n",
+			expectUnchanged: true,
+		},
+		{
+			name:            "comment line with secret-looking content is unchanged",
+			input:           "# token: fake\n",
+			expectUnchanged: true,
+		},
+		{
+			name:            "no sensitive keys leaves input unchanged",
+			input:           "server: https://grafana.example.com\nuser: alice\n",
+			expectUnchanged: true,
+		},
+		// ── edge cases ────────────────────────────────────────────────────
+		{
+			name:  "empty input returns empty output",
+			input: "",
+		},
+		{
+			name:        "windows CRLF line endings are preserved",
+			input:       "token: secret\r\n",
+			notContains: []string{"secret"},
+			contains:    []string{"\r\n"},
+		},
+		{
+			name:        "duplicate keys are both redacted",
+			input:       "token: firstsecret\ntoken: secondsecret\n",
+			notContains: []string{"firstsecret", "secondsecret"},
+			contains:    []string{"token"},
+		},
+		{
+			name:        "value indented under list item is redacted",
+			input:       "- token: xyz\n",
+			notContains: []string{"xyz"},
+			contains:    []string{"token"},
+		},
+		// ── UTF-8 / length preservation ───────────────────────────────────
+		{
+			// 4 x euro-sign (U+20AC, 3 bytes each) = 12 bytes = exactly the sentinel length.
+			name:        "UTF-8 value of exactly sentinel length",
+			input:       "token: " + utf8MultiByteValue + "\n",
+			notContains: []string{utf8MultiByteValue},
+			wantOutput:  "token: **REDACTED**\n",
+		},
+		{
+			// Short secret: value is 1 ASCII byte; sentinel truncates to "*".
+			name:       "short secret under 12 bytes produces truncated sentinel",
+			input:      "token: a\n",
+			wantOutput: "token: *\n",
+		},
+		{
+			// 3-byte UTF-8 rune: sentinel truncates to first 3 bytes "**R".
+			name:       "UTF-8 short secret produces rune-safe truncated sentinel",
+			input:      "token: " + utf8ShortValue + "\n",
+			wantOutput: "token: **R\n",
+		},
+		// ── AC-8: denylist derives entirely from struct reflection ─────────
+		// The synthetic struct below introduces "super-secret" as a new key
+		// that yaml.go has never been told about explicitly.  Redaction must
+		// work purely because of the datapolicy:"secret" tag.
+		{
+			name:        "AC-8 synthetic struct with novel secret field",
+			input:       "super-secret: hiddenvalue\npublic-field: visible\n",
+			root:        reflect.TypeFor[ac8Root](),
+			notContains: []string{"hiddenvalue"},
+			contains:    []string{"public-field: visible"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := require.New(t)
+
+			in := []byte(tt.input)
+			root := testRootType
+			if tt.root != nil {
+				root = tt.root
+			}
+
+			out := secrets.RedactYAMLSecrets(in, root)
+
+			// AC-9: output must have the same byte length as input.
+			req.Len(out, len(in),
+				"output byte length must equal input byte length")
+
+			// AC-9: output must be valid UTF-8 with no split rune.
+			req.True(utf8.Valid(out), "output must be valid UTF-8")
+
+			// Exact output check.
+			if tt.wantOutput != "" {
+				req.Equal(tt.wantOutput, string(out))
+			}
+
+			// Byte-equality for no-op cases.
+			if tt.expectUnchanged {
+				req.Equal(string(in), string(out),
+					"input should be returned unchanged")
+			}
+
+			// Absent substrings.
+			for _, sub := range tt.notContains {
+				req.NotContains(string(out), sub,
+					"sensitive substring %q must not appear in output", sub)
+			}
+
+			// Required substrings.
+			for _, sub := range tt.contains {
+				req.Contains(string(out), sub,
+					"expected substring %q not found in output", sub)
+			}
+		})
+	}
+}
+
+// TestRedactYAMLSecrets_LengthInvariantAllCases re-runs every case and asserts
+// len(out) == len(in) as a belt-and-suspenders check separated from the main
+// table so failures show a dedicated message.
+func TestRedactYAMLSecrets_LengthInvariantAllCases(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		root  reflect.Type
+	}{
+		{"empty", "", testRootType},
+		{"inline token", "token: glc_secret\n", testRootType},
+		{"inline password", "password: hunter2\n", testRootType},
+		{"no sensitive keys", "server: https://x.com\nuser: bob\n", testRootType},
+		{"crlf", "token: secret\r\n", testRootType},
+		{"block scalar", "token: |\n  line1\n  line2\n", testRootType},
+		{"utf8 short", "token: " + utf8ShortValue + "\n", testRootType},
+		{"utf8 exact", "token: " + utf8MultiByteValue + "\n", testRootType},
+		{"ac8 synthetic", "super-secret: x\n", reflect.TypeFor[ac8Root]()},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			in := []byte(c.input)
+			out := secrets.RedactYAMLSecrets(in, c.root)
+			require.Len(t, out, len(in),
+				"len(out) must equal len(in) for %q", c.name)
+			require.True(t, utf8.Valid(out),
+				"output must be valid UTF-8 for %q", c.name)
+		})
+	}
+}
+
+// ── AC-8 supporting type ──────────────────────────────────────────────────────
+
+// ac8Root is a synthetic struct that introduces a secret field ("super-secret")
+// that is unknown to yaml.go's code.  It verifies that denylist derivation is
+// purely reflection-driven and requires no hardcoding.
+type ac8Root struct {
+	SuperSecret string `datapolicy:"secret" yaml:"super-secret"`
+	PublicField string `yaml:"public-field"`
+}


### PR DESCRIPTION
## What

Redact secret values from the config in the printed config snippet shown
upon config errors.

## Why

To prevent secret values being rendered to STDOUT. This currently leads
to secret values leaking in e.g. CI if the config is rendered invalid for
some reason.

## Test Plan
- [x] `go test ./...` — all 9 packages pass
- [x] `go build ./...` — binary compiles cleanly
- [x] `TestLoad_DoesNotLeakSecretsOnError` covers all spec ACs (1–13)
- [x] `TestRedactYAMLSecrets` + `TestRedactYAMLSecrets_LengthInvariantAllCases` cover unit cases
- [x] Smoke test: create malformed config with `token; glc_...` and confirm `grafanactl config check` output does not contain the token value

Generated with [Claude Code](https://claude.com/claude-code)